### PR TITLE
[Bindings.Sofa.Helper] Add MessageHandler context manager class

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -29,11 +29,6 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include <sofa/helper/logging/Messaging.h>
 using sofa::helper::logging::Message;
 
-#include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
-using sofa::helper::logging::MessageDispatcher;
-using sofa::helper::logging::MainPerComponentLoggingMessageHandler;
-
-
 #include <sofa/core/objectmodel/BaseNode.h>
 #include <sofa/core/objectmodel/BaseContext.h>
 #include <sofa/core/behavior/BaseForceField.h>
@@ -113,8 +108,6 @@ PYBIND11_MODULE(Core, core)
                #Sofa.Core.WriteAccessor
        )doc";
 
-    MessageDispatcher::addHandler(&MainPerComponentLoggingMessageHandler::getInstance()) ;
-
     moduleAddPythonScriptEvent();
     moduleAddDataDict(core);
     moduleAddDataDictIterator(core);
@@ -132,12 +125,10 @@ PYBIND11_MODULE(Core, core)
     moduleAddDataEngine(core);
     moduleAddForceField(core);
     moduleAddObjectFactory(core);
-
     moduleAddNode(core);
     moduleAddNodeIterator(core);
     moduleAddPrefab(core);
     moduleAddBaseLink(core);
-
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.cpp
@@ -1,0 +1,135 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#include "Binding_MessageHandler.h"
+#include "Binding_MessageHandler_doc.h"
+
+#include <SofaPython3/DataHelper.h>
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/PythonEnvironment.h>
+using sofapython3::PythonEnvironment;
+
+#include <pybind11/pybind11.h>
+
+#include <sofa/core/objectmodel/Base.h>
+
+PYBIND11_DECLARE_HOLDER_TYPE(PyMessageHandler,
+                             sofapython3::py_shared_ptr<PyMessageHandler>, true)
+
+namespace sofapython3
+{
+    using sofa::core::objectmodel::Event;
+
+    void PyMessageHandler::process(Message& /*m*/) {
+    }
+
+    PyMessageHandler::PyMessageHandler() {
+    }
+
+    PyMessageHandler::~PyMessageHandler() {
+    }
+
+    class MessageHandler_Trampoline : public PyMessageHandler, public PythonTrampoline
+    {
+    public:
+        MessageHandler_Trampoline() = default;
+
+        ~MessageHandler_Trampoline() override = default;
+        virtual void process(Message& m) override ;
+    };
+
+    void MessageHandler_Trampoline::process(Message& m)
+    {
+        PythonEnvironment::gil acquire {"MessageHandler"};
+        py::object self = py::cast(this);
+
+        if( py::hasattr(self, "process") )
+        {
+            auto typeStr = [&m]() -> std::string {
+                switch (m.type())
+                {
+                    case Message::Type::Info:
+                    return "Info";
+                    case Message::Type::Error:
+                    return "Error";
+                    case Message::Type::Fatal:
+                    return "Fatal";
+                    case Message::Type::Advice:
+                    return "Advice";
+                    case Message::Type::Warning:
+                    return "Warning";
+                    case Message::Type::Deprecated:
+                    return "Deprecated";
+                    default:
+                    return "Other";
+                }
+            };
+
+            auto component = [&m]() {
+                sofa::helper::logging::SofaComponentInfo* nfo = dynamic_cast<sofa::helper::logging::SofaComponentInfo*>(m.componentInfo().get());
+                if( nfo != nullptr )
+                    return py::cast(nfo->m_component);
+                return py::object();
+            };
+
+            py::dict msg("type"_a=typeStr,
+                         "isEmpty"_a=m.empty(),
+                         "sender"_a=m.sender(),
+                         "message"_a=m.messageAsString(),
+                         "component"_a=component
+                    );
+
+            py::object fct = self.attr("process")(msg);
+        }
+    }
+
+
+    void moduleAddMessageHandler(py::module &m) {
+        py::class_<PyMessageHandler,
+                MessageHandler_Trampoline,
+                std::unique_ptr<PyMessageHandler>> f(m, "MessageHandler",
+                                             py::dynamic_attr(),
+                                             py::multiple_inheritance());
+
+        f.def(py::init([]()
+        {
+            return new MessageHandler_Trampoline();
+        }));
+
+        f.def("process", &PyMessageHandler::process);
+        f.def("__enter__", [](PyMessageHandler* self){
+            PythonEnvironment::gil acquire {"MessageHandler"};
+            sofa::helper::logging::MessageDispatcher::addHandler(self);
+        });
+        f.def("__exit__", [](PyMessageHandler* self){
+            PythonEnvironment::gil acquire {"MessageHandler"};
+            sofa::helper::logging::MessageDispatcher::rmHandler(self);
+        });
+    }
+
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.cpp
@@ -122,13 +122,11 @@ namespace sofapython3
         f.def("process", &PyMessageHandler::process);
         f.def("__enter__", [](PyMessageHandler* self) -> PyMessageHandler*
         {
-            PythonEnvironment::gil acquire {"MessageHandler"};
             sofa::helper::logging::MessageDispatcher::addHandler(self);
             return self;
         });
         f.def("__exit__", [](PyMessageHandler* self, py::object /*exc_type*/, py::object /*exc_value*/, py::object /*traceback*/)
         {
-            PythonEnvironment::gil acquire {"MessageHandler"};
             sofa::helper::logging::MessageDispatcher::rmHandler(self);
         });
     }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.h
@@ -1,0 +1,64 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+#include <sofa/helper/logging/MessageHandler.h>
+#include <pybind11/pybind11.h>
+
+/// Forward declaration
+namespace sofa {
+    namespace helper {
+        namespace logging {
+            class Message;
+        }
+    }
+}
+
+namespace sofapython3
+{
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+using namespace pybind11::literals;
+using sofa::helper::logging::Message ;
+using sofa::helper::logging::MessageHandler ;
+
+class PyMessageHandler: public MessageHandler
+{
+public:
+    virtual void process(Message& m) override ;
+
+    PyMessageHandler();
+    ~PyMessageHandler() override;
+};
+
+void moduleAddMessageHandler(py::module &m);
+
+} /// namespace sofapython3
+

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
@@ -4,11 +4,13 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Helper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Vector.h
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Submodule_System.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_MessageHandler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Binding_FileRepository.h
 )
 
 set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Helper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_MessageHandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Vector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Submodule_System.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Binding_FileRepository.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -31,6 +31,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include <sofa/core/objectmodel/Base.h>
 #include "System/Submodule_System.h"
 #include "Submodule_Helper.h"
+#include "Binding_MessageHandler.h"
 #include "Binding_Vector.h"
 
 namespace sofapython3
@@ -151,6 +152,7 @@ PYBIND11_MODULE(Helper, helper)
     helper.def("msg_fatal", [](py::args args) { MESSAGE_DISPATCH(msg_fatal); },
     R"(Emit a fatal error message from python.)");
 
+    moduleAddMessageHandler(helper);
     moduleAddVector(helper);
     moduleAddSystem(helper);
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
@@ -18,5 +18,5 @@ SP3_add_python_module(
         MODULE_NAME  Simulation
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
-        DEPENDS      SofaHelper SofaCore SofaSimulationCore SofaSimulationGraph SofaBaseVisual
+        DEPENDS      SofaCore SofaSimulationCore SofaSimulationGraph SofaBaseVisual
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
@@ -18,5 +18,5 @@ SP3_add_python_module(
         MODULE_NAME  Simulation
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
-        DEPENDS      SofaCore SofaSimulationCore SofaSimulationGraph SofaBaseVisual
+        DEPENDS      SofaHelper SofaCore SofaSimulationCore SofaSimulationGraph SofaBaseVisual
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -40,11 +40,6 @@ using namespace pybind11::literals;
 using sofa::simulation::Simulation;
 
 #include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/logging/MessageDispatcher.h>
-#include <sofa/helper/logging/ConsoleMessageHandler.h>
-#include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
-using sofa::helper::logging::MessageDispatcher;
-using sofa::helper::logging::MainPerComponentLoggingMessageHandler;
 #include "Submodule_Simulation_doc.h"
 
 namespace py = pybind11;
@@ -61,7 +56,7 @@ PYBIND11_MODULE(Simulation, simulation)
 
     simulation.def("print", [](Node* n){ sofa::simulation::getSimulation()->print(n); }, sofapython3::doc::simulation::print);
     simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::getSimulation()->animate(n, dt); },sofapython3::doc::simulation::animate);
-    simulation.def("init", [](Node* n) { sofa::simulation::getSimulation()->init(n); }, sofapython3::doc::simulation::init);
+    simulation.def("init", [](Node* n){ sofa::simulation::getSimulation()->init(n); }, sofapython3::doc::simulation::init);
     simulation.def("initVisual", [](Node* n){ n->getVisualLoop()->initStep(sofa::core::visual::VisualParams::defaultInstance()); });
     simulation.def("reset", [](Node* n){ sofa::simulation::getSimulation()->reset(n); }, sofapython3::doc::simulation::reset);
     simulation.def("load", [](const std::string & name) {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -41,8 +41,10 @@ using sofa::simulation::Simulation;
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/logging/MessageDispatcher.h>
-using sofa::helper::logging::MessageDispatcher;
 #include <sofa/helper/logging/ConsoleMessageHandler.h>
+#include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
+using sofa::helper::logging::MessageDispatcher;
+using sofa::helper::logging::MainPerComponentLoggingMessageHandler;
 #include "Submodule_Simulation_doc.h"
 
 namespace py = pybind11;
@@ -59,11 +61,7 @@ PYBIND11_MODULE(Simulation, simulation)
 
     simulation.def("print", [](Node* n){ sofa::simulation::getSimulation()->print(n); }, sofapython3::doc::simulation::print);
     simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::getSimulation()->animate(n, dt); },sofapython3::doc::simulation::animate);
-    simulation.def("init", [](Node* n){
-	sofa::simulation::getSimulation()->init(n);
-	MessageDispatcher::clearHandlers();
-	MessageDispatcher::addHandler(new sofa::helper::logging::ConsoleMessageHandler());
-      }, sofapython3::doc::simulation::init);
+    simulation.def("init", [](Node* n) { sofa::simulation::getSimulation()->init(n); }, sofapython3::doc::simulation::init);
     simulation.def("initVisual", [](Node* n){ n->getVisualLoop()->initStep(sofa::core::visual::VisualParams::defaultInstance()); });
     simulation.def("reset", [](Node* n){ sofa::simulation::getSimulation()->reset(n); }, sofapython3::doc::simulation::reset);
     simulation.def("load", [](const std::string & name) {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -40,6 +40,8 @@ using namespace pybind11::literals;
 using sofa::simulation::Simulation;
 
 #include <sofa/core/visual/VisualParams.h>
+#include <sofa/helper/logging/MessageDispatcher.h>
+#include <sofa/helper/logging/ConsoleMessageHandler.h>
 #include "Submodule_Simulation_doc.h"
 
 namespace py = pybind11;
@@ -56,7 +58,11 @@ PYBIND11_MODULE(Simulation, simulation)
 
     simulation.def("print", [](Node* n){ sofa::simulation::getSimulation()->print(n); }, sofapython3::doc::simulation::print);
     simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::getSimulation()->animate(n, dt); },sofapython3::doc::simulation::animate);
-    simulation.def("init", [](Node* n){ sofa::simulation::getSimulation()->init(n); }, sofapython3::doc::simulation::init);
+    simulation.def("init", [](Node* n){
+	sofa::simulation::getSimulation()->init(n);
+	MessageDispatcher::clearHandlers();
+	MessageDispatcher::addHandler(new sofa::helper::logging::ConsoleMessageHandler());
+      }, sofapython3::doc::simulation::init);
     simulation.def("initVisual", [](Node* n){ n->getVisualLoop()->initStep(sofa::core::visual::VisualParams::defaultInstance()); });
     simulation.def("reset", [](Node* n){ sofa::simulation::getSimulation()->reset(n); }, sofapython3::doc::simulation::reset);
     simulation.def("load", [](const std::string & name) {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -41,6 +41,7 @@ using sofa::simulation::Simulation;
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/logging/MessageDispatcher.h>
+using sofa::helper::logging::MessageDispatcher;
 #include <sofa/helper/logging/ConsoleMessageHandler.h>
 #include "Submodule_Simulation_doc.h"
 

--- a/bindings/Sofa/tests/Helper/Message.py
+++ b/bindings/Sofa/tests/Helper/Message.py
@@ -4,6 +4,23 @@ import Sofa
 import Sofa.Helper
 import unittest
 
+class MsgHandler(Sofa.Helper.MessageHandler):
+    def __init__(self):
+        Sofa.Helper.MessageHandler.__init__(self)
+
+    def process(msg):
+        print ("GOT MESSAGE!")
+        print("type: ")
+        print(msg.type)
+        print("sender: ")
+        print(msg.sender)
+        print("component: ")
+        print(msg.component.typeName())
+        print(msg.component.getName())
+        print("message:")
+        print(msg.message)
+
+
 class Test(unittest.TestCase):
     def test_messages(self):
         """Test that the message are correctly sended and does not generates exceptions"""
@@ -14,4 +31,13 @@ class Test(unittest.TestCase):
             f("Simple message with attached source info", "sourcefile.py", 10)
             f(Sofa.Core.Node("node"), "Simple message to an object")
             f(Sofa.Core.Node("node"), "Simple message to an object with attached source info", "sourcefile.py", 10)
+
+
+
+    def test_messageHandler(self):
+        with MsgHandler():
+            Sofa.Helper.msg_info("plop")
+            Sofa.Helper.msg_error("pouet")
+        Sofa.Helper.msg_warning("coucou")
+
 

--- a/bindings/Sofa/tests/Helper/Message.py
+++ b/bindings/Sofa/tests/Helper/Message.py
@@ -8,17 +8,11 @@ class MsgHandler(Sofa.Helper.MessageHandler):
     def __init__(self):
         Sofa.Helper.MessageHandler.__init__(self)
 
-    def process(msg):
-        print ("GOT MESSAGE!")
-        print("type: ")
-        print(msg.type)
-        print("sender: ")
-        print(msg.sender)
-        print("component: ")
-        print(msg.component.typeName())
-        print(msg.component.getName())
-        print("message:")
-        print(msg.message)
+    def process(self, msg):
+        self.type = msg["type"]
+        self.sender = msg["sender"]
+        self.component = msg["component"]
+        self.message = msg["message"]
 
 
 class Test(unittest.TestCase):
@@ -35,9 +29,17 @@ class Test(unittest.TestCase):
 
 
     def test_messageHandler(self):
-        with MsgHandler():
+        with MsgHandler() as handler:
             Sofa.Helper.msg_info("plop")
-            Sofa.Helper.msg_error("pouet")
-        Sofa.Helper.msg_warning("coucou")
+            self.assertEqual(handler.type, "Info")
+            self.assertEqual(handler.sender, "PythonScript")
+            self.assertEqual(handler.component, None)
+            self.assertEqual(handler.message, "plop")
+
+            Sofa.Helper.msg_warning("coucou")
+            self.assertEqual(handler.type, "Warning")
+            self.assertEqual(handler.sender, "PythonScript")
+            self.assertEqual(handler.component, None)
+            self.assertEqual(handler.message, "coucou")
 
 

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -157,7 +157,7 @@ class Test(unittest.TestCase):
 
             self.assertEqual(root["node1.node2.object2.name"], root.node1.node2.object2.name)
 
-	def test_getRoot(self):
+        def test_getRoot(self):
             root = Sofa.Core.Node("root")
             node = root.addChild("node")
             self.assertEqual(node.getRoot(), root)

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
@@ -65,6 +65,13 @@ using sofapython3::SceneLoaderPY3;
 
 #include <SofaPython3/DataHelper.h>
 
+#include <sofa/helper/logging/MessageDispatcher.h>
+#include <sofa/helper/logging/ConsoleMessageHandler.h>
+#include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
+using sofa::helper::logging::MessageDispatcher;
+using sofa::helper::logging::MainPerComponentLoggingMessageHandler;
+using sofa::helper::logging::MainConsoleMessageHandler;
+
 namespace sofapython3
 {
 
@@ -129,6 +136,12 @@ PYBIND11_MODULE(SofaRuntime, m) {
     {
         return simpleapi::importPlugin(name);
     }, "import a sofa plugin into the current environment");
+
+    m.def("init", []() {
+        MessageDispatcher::clearHandlers();
+        MessageDispatcher::addHandler(&MainConsoleMessageHandler::getInstance());
+        MessageDispatcher::addHandler(&MainPerComponentLoggingMessageHandler::getInstance());
+    });
 
     m.add_object("DataRepository", py::cast(&sofa::helper::system::DataRepository));
     m.add_object("PluginRepository", py::cast(&sofa::helper::system::PluginRepository));


### PR DESCRIPTION
This PR lets you write MessageHandlers in Python.
It also lets you instantiate them in a RAII way by taking advantage of Python3's context managers.

All you have to do is implement the process function in a MessageHandler-inherited python class (see diff in Message.py)
@damienmarchal @jnbrunet 