### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This project is composed of a Sofa plugin to embed a python interpreter into a Sofa based simulation as well as several python modules that exposes the different c++ components used in Sofa. The binding is designed to be idiomatic python3 API with tight integration for numpy. This project is in a WIP state, please use it only if you are willing to help in the developement. 
 
 ## Installation 
+*Special note for Mac users:* Some users reported issue when compiling SOFA with SP3 on mac, using `boost < 1.70`. It would seem that boost uses the deprecated STL smart pointer `auto_ptr` which has been removed entirely from the standard library on some of the latest versions of MacOS. To fix this, install a more recent version of boost (>1.70 should do) 
 
 ### Requirement Install
 - pybind11 (minimal 2.3)


### PR DESCRIPTION
@jnbrunet, Bruno Carrez got this error when trying to build SOFA with SP3 on Mac after upgrading his system to a newer version of MacOS:

```
FAILED: SofaGeneral/SofaGeneralLoader/CMakeFiles/SofaGeneralLoader.dir/GIDMeshLoader.cpp.o 
/usr/local/bin/ccache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DSOFA_BUILD_GENERAL_LOADER -DSOFA_BUILD_SOFAGENERALLOADER -DSofaGeneralLoader_EXPORTS -I/Users/bcarrez/git/runsofa2/sofa/modules/SofaGeneralLoader/.. -Iinclude/SofaGeneral -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaCore/src -Iinclude/SofaFramework -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/src -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/../SofaSimulationCore/src -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/../SofaDefaultType/src -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/../SofaCore/src -Iinclude/GTest -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaDefaultType/src -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaSimulationTree/.. -Iinclude/SofaSimulation -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaSimulationCommon/.. -I/Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaSimulationCore/src -isystem /Users/bcarrez/git/runsofa2/sofa/SofaKernel/extlibs/json -iframework /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks -isystem /usr/local/include -isystem /Users/bcarrez/git/runsofa2/sofa/extlibs/gtest/include -isystem /usr/local/include/eigen3 -Wall -W -Wno-padded -DGL_SILENCE_DEPRECATION -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -fPIC   -DFRAMEWORK_TEST_RESOURCES_DIR=\"/Users/bcarrez/git/runsofa2/sofa/SofaKernel/SofaFramework/resources/tests\" -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -std=gnu++1z -MD -MT SofaGeneral/SofaGeneralLoader/CMakeFiles/SofaGeneralLoader.dir/GIDMeshLoader.cpp.o -MF SofaGeneral/SofaGeneralLoader/CMakeFiles/SofaGeneralLoader.dir/GIDMeshLoader.cpp.o.d -o SofaGeneral/SofaGeneralLoader/CMakeFiles/SofaGeneralLoader.dir/GIDMeshLoader.cpp.o -c /Users/bcarrez/git/runsofa2/sofa/modules/SofaGeneralLoader/GIDMeshLoader.cpp
In file included from /Users/bcarrez/git/runsofa2/sofa/modules/SofaGeneralLoader/GIDMeshLoader.cpp:26:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaCore/src/sofa/core/ObjectFactory.h:25:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseObject.h:25:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/BaseContext.h:25:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaCore/src/sofa/core/objectmodel/Base.h:26:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/../SofaDefaultType/src/sofa/defaulttype/BoundingBox.h:27:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/../SofaDefaultType/src/sofa/defaulttype/Vec.h:27:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/../SofaDefaultType/src/sofa/defaulttype/DataTypeInfo.h:27:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/src/sofa/helper/vector.h:37:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/Messaging.h:81:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/MessageDispatcher.h:30:
In file included from /Users/bcarrez/git/runsofa2/sofa/SofaKernel/modules/SofaHelper/src/sofa/helper/logging/Message.h:35:
In file included from /usr/local/include/boost/shared_ptr.hpp:17:
In file included from /usr/local/include/boost/smart_ptr/shared_ptr.hpp:28:
/usr/local/include/boost/smart_ptr/detail/shared_count.hpp:402:33: error: no template named 'auto_ptr' in namespace 'std'
    explicit shared_count( std::auto_ptr<Y> & r ): pi_( new sp_counted_impl_p<Y>( r.get() ) )
                           ~^
```

Upgrading boost to v1.70 fixed the problem, because in this version of boost, the use of auto_ptr in the implementation of the shared_ptr has been replaced by something else.
Weirdly though, the problem only appears if SP3 is being compiled with SOFA... while the error happens in SOFA and doesn't seem to be anyhow related to SP3...