### PR TITLE
[SofaPython3/binding/Sofa] Add a first test for simulation.

### DIFF
--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PYTHON_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Types/Vec3.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Types/BoundingBox.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Simulation/Node.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/Simulation/Simulation.py
     ${CMAKE_CURRENT_SOURCE_DIR}/bench_datacontainer.py
     ${CMAKE_CURRENT_SOURCE_DIR}/bench_node.py
     ${CMAKE_CURRENT_SOURCE_DIR}/benchmark.py

--- a/bindings/Sofa/tests/Simulation/Simulation.py
+++ b/bindings/Sofa/tests/Simulation/Simulation.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*
+import Sofa
+import unittest
+import Sofa.Core
+import Sofa.Types
+import Sofa.Simulation
+import tempfile
+
+class Test(unittest.TestCase):
+    def test_load(self):
+        """Create a scene and load it to validate the loading function"""
+        scene="""
+            <Node name="rootNode" dt="0.005" gravity="0 0 0">
+                <Node name="child1">
+                </Node>
+                <Node name="child2">
+                </Node>
+            </Node>
+        """
+        tf = tempfile.NamedTemporaryFile(mode="w+t", suffix=".scn")
+        tf.file.write(scene)
+        tf.file.flush()
+        tt = open(tf.name)
+        node = Sofa.Simulation.load(tf.name)
+        self.assertNotEqual(node, None)
+        self.assertEqual(node.name.value, "rootNode")
+


### PR DESCRIPTION
Someone reported a bug on simulation.load. 
I noticed that there was not test for this binding so I added one. 