### PR TITLE
[SofaPython3] Add a per-keyword setData function

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -25,7 +25,6 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
     - thierry.gaugry@inria.fr
 ********************************************************************/
 
-
 #include <pybind11/pybind11.h>
 
 #include <pybind11/numpy.h>
@@ -395,6 +394,19 @@ py::object BindingBase::getData(Base& self, const std::string& s)
     return py::none();
 }
 
+py::object BindingBase::setDataValues(Base& self, py::kwargs kwargs)
+{
+    for(auto key : kwargs)
+    {
+        BaseData* d = self.findData(py::cast<std::string>(key.first));
+        if(d!=nullptr)
+            PythonFactory::fromPython(d, py::cast<py::object>(key.second));
+        else
+            throw py::attribute_error("There is no data field named: "+py::cast<std::string>(key.first));
+    }
+    return py::none();
+}
+
 void moduleAddBase(py::module &m)
 {
     py::class_<Base, Base::SPtr> base(m, "Base", py::dynamic_attr(), doc::base::BaseClass);
@@ -428,6 +440,7 @@ void moduleAddBase(py::module &m)
     base.def("getLoggedMessagesAsString", &BindingBase::getLoggedMessagesAsString, sofapython3::doc::base::getLoggedMessagesAsString);
     base.def("countLoggedMessages", &BindingBase::countLoggedMessages, sofapython3::doc::base::countLoggedMessages);
     base.def("clearLoggedMessages", &BindingBase::clearLoggedMessages, sofapython3::doc::base::clearLoggedMessages);
+    base.def("setDataValues", &BindingBase::setDataValues, sofapython3::doc::base::setDataValues);
 }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
@@ -65,6 +65,7 @@ public:
     /// Set the data field value from the array.
     static void SetDataFromArray(BaseData* data, const py::array& value);
     static bool SetData(BaseData* data, pybind11::object value);
+    static py::object setDataValues(Base& self, py::kwargs kwargs);
 
     static py::list getDataFields(Base& self);
     static py::list getLinks(Base& self);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
@@ -70,6 +70,10 @@ static auto findData =
         :type name: string
         :return: the data field
         )";
+static auto setDataValues =
+        R"(
+        Set values for a the given data field, multiple pairs of args are allowed.
+        )";
 static auto getDataFields =
         R"(
         Accessor to the vector containing all the fields of this object


### PR DESCRIPTION
I often have to change a lot of data field for the same object. 
This function allows to do that by using the kwargs to set name=value.

A quick example
```python
    myobject.setDataValues(position=[1.0,2.0,3.0], 
                                           velocity=[2.0,3.0, 4.0])
```   
