### PR TITLE
ADD: PrefabLinks

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -541,12 +541,11 @@ BaseData* addData(py::object py_self, const std::string& name, py::object value,
     BaseData* data;
 
     bool isSet = true;
-    if (value.is(py::none()))
+    if (value.is_none() && !defaultValue.is_none())
     {
         value = defaultValue;
         isSet = false;
     }
-
 
     // create the data from the link passed as a string to the object
     if (py::isinstance<py::str>(value) &&
@@ -564,7 +563,7 @@ BaseData* addData(py::object py_self, const std::string& name, py::object value,
         self->addData(data, name);
     }
     // create the data from another data (use as parent)
-    else if (py::isinstance<BaseData>(value) || py::isinstance<BaseData*>(value))
+    else if (!value.is_none() && (py::isinstance<BaseData>(value) || py::isinstance<BaseData*>(value)))
     {
         data = deriveTypeFromParent(py::cast<BaseData*>(value));
         if (!data)
@@ -587,7 +586,8 @@ BaseData* addData(py::object py_self, const std::string& name, py::object value,
             throw py::type_error(std::string("Invalid Type string: available types are\n") + typesString);
         }
         self->addData(data, name);
-        PythonFactory::fromPython(data, value);
+        if (!value.is_none())
+            PythonFactory::fromPython(data, value);
     }
     data->setName(name);
     data->setGroup(group.c_str());

--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -541,7 +541,7 @@ BaseData* addData(py::object py_self, const std::string& name, py::object value,
     BaseData* data;
 
     bool isSet = true;
-    if (value.is_none() && !defaultValue.is_none())
+    if (value.is_none())
     {
         value = defaultValue;
         isSet = false;

--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -21,9 +21,9 @@ using sofa::core::objectmodel::Event;
 
 void Prefab::init()
 {
-    std::cout << "prefab::init" << std::endl;
     reinit();
     Inherit1::init(sofa::core::ExecParams::defaultInstance());
+    m_is_initialized = true;
 }
 
 void PrefabFileEventListener::fileHasChanged(const std::string &filename)
@@ -44,21 +44,16 @@ void PrefabFileEventListener::fileHasChanged(const std::string &filename)
 
 void Prefab::reinit()
 {
-    std::cout << "prefab::reinit" << std::endl;
     clearLoggedMessages();
 
     /// remove everything in the node.
     execute<sofa::simulation::DeleteVisitor>(sofa::core::ExecParams::defaultInstance());
-    std::cout << "prefab::doReInit" << std::endl;
+
     doReInit();
 
-    std::cout << "simulation->initNode" << std::endl;
     /// Beurk beurk beurk
     sofa::simulation::getSimulation()->initNode(this);
-    std::cout << "VisualInitVisitor" << std::endl;
     execute<VisualInitVisitor>(nullptr);
-
-    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 void Prefab::doReInit()
@@ -83,19 +78,18 @@ void Prefab::addPrefabParameter(const std::string& name, const std::string& help
     if(!findData(name) && !findLink(name))
     {
         sofa::core::objectmodel::BaseData* data = sofapython3::addData(py::cast(this), name, py::none(), defaultValue, help, "Prefab's properties", type);
+        data->setRequired(true);
         m_datacallback.addInputs({data});
     }
 }
 
 void Prefab::setSourceTracking(const std::string& filename)
 {
-    std::cout << "Activating source tracking to " << filename << std::endl;
     FileMonitor::addFile(filename, &m_filelistener);
 }
 
 void Prefab::breakPrefab()
 {
-    std::cout << "Breaking prefab" << std::endl;
     FileMonitor::removeListener(&m_filelistener);
     for (auto& data : this->getDataFields())
         if (data->getGroup() == "Prefab's properties")

--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -58,7 +58,7 @@ void Prefab::reinit()
     std::cout << "VisualInitVisitor" << std::endl;
     execute<VisualInitVisitor>(nullptr);
 
-    m_componentstate = sofa::core::objectmodel::ComponentState::Valid;
+    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 void Prefab::doReInit()

--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -78,30 +78,14 @@ Prefab::~Prefab()
 }
 
 
-void Prefab::addDataParameter(const std::string& name, py::object value, const std::string& help, std::string type)
+void Prefab::addPrefabParameter(const std::string& name, const std::string& help, const std::string& type, py::object defaultValue)
 {
     if(!findData(name) && !findLink(name))
     {
-        sofa::core::objectmodel::BaseData* data = sofapython3::addData(py::cast(this), name, value, py::object(), help, "Prefab's properties", type);
+        sofa::core::objectmodel::BaseData* data = sofapython3::addData(py::cast(this), name, py::none(), defaultValue, help, "Prefab's properties", type);
         m_datacallback.addInputs({data});
-        return;
     }
-    //PythonFactory::fromPython(data, value);
 }
-
-void Prefab::addLinkParameter(const std::string& name, const std::string& help)
-{
-    if(!findData(name) && !findLink(name))
-    {
-        sofa::core::objectmodel::BaseData* data = sofapython3::addData(py::cast(this), name, py::none(), py::none(), help, "Prefab's properties", "PrefabLink");
-        std::cout << data->getName() << " Successfully created!" << std::endl;
-        m_datacallback.addInputs({data});
-        return;
-    }
-    std::cout << name << " Already exist in " << this->getName() << "!!!" << std::endl;
-    //PythonFactory::fromPython(data, value);
-}
-
 
 void Prefab::setSourceTracking(const std::string& filename)
 {

--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -78,10 +78,9 @@ Prefab::~Prefab()
 }
 
 
-void Prefab::addPrefabParameter(const std::string& name, py::object value, const std::string& help, std::string type)
+void Prefab::addDataParameter(const std::string& name, py::object value, const std::string& help, std::string type)
 {
-    sofa::core::objectmodel::BaseData* data = findData(name);
-    if(data == nullptr)
+    if(!findData(name) && !findLink(name))
     {
         sofa::core::objectmodel::BaseData* data = sofapython3::addData(py::cast(this), name, value, py::object(), help, "Prefab's properties", type);
         m_datacallback.addInputs({data});
@@ -89,6 +88,22 @@ void Prefab::addPrefabParameter(const std::string& name, py::object value, const
     }
     //PythonFactory::fromPython(data, value);
 }
+
+void Prefab::addLinkParameter(const std::string& name, py::object value, const std::string& help)
+{
+    if(!findData(name) && !findLink(name))
+    {
+        sofa::core::objectmodel::BaseLink* link = sofapython3::addLink(py::cast(this), name, value, help);
+
+        // can't set the link into the "Prefab" group because links have no setGroup function
+        // link->setGroup("Prefab's properties");
+        // can't add the link to the datacallback's inputs, since links aren't DDGNodes...
+        // m_datacallback.addInputs({link});
+        return;
+    }
+    //PythonFactory::fromPython(data, value);
+}
+
 
 void Prefab::setSourceTracking(const std::string& filename)
 {

--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -89,18 +89,16 @@ void Prefab::addDataParameter(const std::string& name, py::object value, const s
     //PythonFactory::fromPython(data, value);
 }
 
-void Prefab::addLinkParameter(const std::string& name, py::object value, const std::string& help)
+void Prefab::addLinkParameter(const std::string& name, const std::string& help)
 {
     if(!findData(name) && !findLink(name))
     {
-        sofa::core::objectmodel::BaseLink* link = sofapython3::addLink(py::cast(this), name, value, help);
-
-        // can't set the link into the "Prefab" group because links have no setGroup function
-        // link->setGroup("Prefab's properties");
-        // can't add the link to the datacallback's inputs, since links aren't DDGNodes...
-        // m_datacallback.addInputs({link});
+        sofa::core::objectmodel::BaseData* data = sofapython3::addData(py::cast(this), name, py::none(), py::none(), help, "Prefab's properties", "PrefabLink");
+        std::cout << data->getName() << " Successfully created!" << std::endl;
+        m_datacallback.addInputs({data});
         return;
     }
+    std::cout << name << " Already exist in " << this->getName() << "!!!" << std::endl;
     //PythonFactory::fromPython(data, value);
 }
 

--- a/Plugin/src/SofaPython3/Prefab.h
+++ b/Plugin/src/SofaPython3/Prefab.h
@@ -48,5 +48,6 @@ public:
 
     PrefabFileEventListener m_filelistener;
     DataCallback m_datacallback;
+    bool m_is_initialized {false};
 };
 }  // namespace sofapython3

--- a/Plugin/src/SofaPython3/Prefab.h
+++ b/Plugin/src/SofaPython3/Prefab.h
@@ -39,7 +39,8 @@ public:
     void reinit();
     virtual void doReInit() ;
 
-    void addPrefabParameter(const std::string& name, pybind11::object value, const std::string& help, std::string type);
+    void addDataParameter(const std::string& name, pybind11::object value, const std::string& help, std::string type);
+    void addLinkParameter(const std::string& name, const std::string& help);
     void setSourceTracking(const std::string& filename);
     void breakPrefab();
 

--- a/Plugin/src/SofaPython3/Prefab.h
+++ b/Plugin/src/SofaPython3/Prefab.h
@@ -39,8 +39,7 @@ public:
     void reinit();
     virtual void doReInit() ;
 
-    void addDataParameter(const std::string& name, pybind11::object value, const std::string& help, std::string type);
-    void addLinkParameter(const std::string& name, const std::string& help);
+    void addPrefabParameter(const std::string& name, const std::string& help, const std::string& type, pybind11::object defaultValue = py::none());
     void setSourceTracking(const std::string& filename);
     void breakPrefab();
 

--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -437,6 +437,9 @@ bool PythonFactory::registerDefaultTypes()
     // helper vector style containers
     std::string containers[] = {"vector"};
 
+    // PrefabLink
+    PythonFactory::registerType<sofa::core::objectmodel::PrefabLink>("PrefabLink");
+
     // Scalars
     PythonFactory::registerType<std::string>("string");
     PythonFactory::registerType<float>("float");

--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -439,6 +439,7 @@ bool PythonFactory::registerDefaultTypes()
 
     // PrefabLink
     PythonFactory::registerType<sofa::core::objectmodel::PrefabLink>("PrefabLink");
+    PythonFactory::registerType<sofa::core::objectmodel::PrefabLink>("Link");
 
     // Scalars
     PythonFactory::registerType<std::string>("string");

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -116,8 +116,10 @@ void moduleAddPrefab(py::module &m) {
           ));
 
     f.def("setSourceTracking", &Prefab::setSourceTracking);
-    f.def("addPrefabParameter", &Prefab::addPrefabParameter,
+    f.def("addDataParameter", &Prefab::addDataParameter,
           "name"_a, "value"_a, "help"_a, "type"_a);
+    f.def("addLinkParameter", &Prefab::addLinkParameter,
+          "name"_a, "help"_a);
     f.def("init", &Prefab::init);
     f.def("reinit", &Prefab::reinit);
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -68,10 +68,17 @@ public:
 
 void Prefab_Trampoline::doReInit()
 {
+    if (!m_is_initialized) {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Loading);
+        msg_warning(this) << "Prefab instantiated. Check for required prefab parameters to fully populate";
+        return;
+    }
     try{
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
         PYBIND11_OVERLOAD(void, Prefab, doReInit, );
     } catch (std::exception& e)
     {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         msg_error(this) << e.what();
     }
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -98,8 +98,6 @@ void moduleAddPrefab(py::module &m) {
                   std::string key = py::cast<std::string>(kv.first);
                   py::object value = py::reinterpret_borrow<py::object>(kv.second);
 
-                  std::cout << "PREFAB ARE BROKEN " << key << std::endl;
-
                   if( key == "name")
                       c->setName(py::cast<std::string>(kv.second));
                   try {
@@ -116,10 +114,8 @@ void moduleAddPrefab(py::module &m) {
           ));
 
     f.def("setSourceTracking", &Prefab::setSourceTracking);
-    f.def("addDataParameter", &Prefab::addDataParameter,
-          "name"_a, "value"_a, "help"_a, "type"_a);
-    f.def("addLinkParameter", &Prefab::addLinkParameter,
-          "name"_a, "help"_a);
+    f.def("addPrefabParameter", &Prefab::addPrefabParameter,
+          "name"_a, "help"_a, "type"_a, "default"_a = py::none());
     f.def("init", &Prefab::init);
     f.def("reinit", &Prefab::reinit);
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataContainer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataContainer_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataString.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataLink.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataString_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataVectorString.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataVectorString_doc.h
@@ -52,6 +53,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataContainer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataString.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataLink.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataVectorString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Visitor.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.cpp
@@ -1,0 +1,60 @@
+#include "Binding_DataLink.h"
+
+#include <sofa/core/objectmodel/BaseData.h>
+using sofa::core::objectmodel::BaseData;
+
+
+#include <SofaPython3/DataHelper.h>
+using sofa::core::objectmodel::PrefabLink;
+#include <SofaPython3/PythonFactory.h>
+
+namespace sofapython3
+{
+
+py::str getTargetPath(PrefabLink& link)
+{
+    return link.getTargetPath();
+}
+
+py::object getTargetBase(PrefabLink& link)
+{
+    auto base = link.getTargetBase().get();
+    if (base)
+        return PythonFactory::toPython(base);
+    return py::none();
+}
+
+py::str DataLink::__str__()
+{
+    std::stringstream s;
+    s << "Sofa.Core.DataLink<name='" << getName()
+      << "', value='" << getValueString()
+      << "', address='"<< (void*)this <<"'>";
+    return s.str();
+}
+
+py::str DataLink::__repr__()
+{
+    return py::repr(convertToPython(this));
+}
+
+void moduleAddDataLink(py::module &m)
+{
+    py::class_<PrefabLink, std::unique_ptr<PrefabLink, py::nodelete>> l(m, "PrefabLink");
+    l.def(py::init<const Base::SPtr&>());
+    l.def(py::init<BaseLink*>());
+    l.def(py::init<const std::string&>());
+    l.def("getTargetBase", &getTargetBase);
+    l.def("getTargetPath", &getTargetPath);
+
+    py::class_<DataLink, BaseData, std::unique_ptr<DataLink, py::nodelete>> d(m, "DataLink");
+
+    PythonFactory::registerType("DataLink", [](BaseData* data) -> py::object {
+        return py::cast(reinterpret_cast<DataLink*>(data));
+    });
+
+    d.def("__repr__",&DataLink::__repr__);
+    d.def("__str__", &DataLink::__str__);
+}
+
+}  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <sofa/core/objectmodel/BaseData.h>
+
+namespace sofapython3
+{
+
+namespace py { using namespace pybind11; }
+using sofa::core::objectmodel::BaseData;
+
+void moduleAddDataLink(py::module& m);
+
+class DataLink : public BaseData
+{
+public:
+    py::str __str__();
+    py::str __repr__();
+};
+
+}  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -52,6 +52,7 @@ using sofa::helper::logging::Message;
 #include "Binding_PythonScriptEvent.h"
 
 #include "Data/Binding_DataString.h"
+#include "Data/Binding_DataLink.h"
 #include "Data/Binding_DataVectorString.h"
 #include "Data/Binding_DataContainer.h"
 
@@ -117,6 +118,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddDataContainerContext(core);
     moduleAddDataContainer(core);
     moduleAddDataString(core);
+    moduleAddDataLink(core);
     moduleAddDataVectorString(core);
     moduleAddBaseObject(core);
     moduleAddBaseCamera(core);


### PR DESCRIPTION
Adding the possibility to create "PrefabLinks" on prefab components. Contrary to legacy links, PrefabLinks are:
- Only instantiable on prefabs (for now at least)
- Inheriting Data, thus can be added to callbacks, added to data groups, etc.

PrefabLinks are used to create blackbox-like interfaces for Sofa.Prefabs in the GUI, where Prefabs expose very visually their dependencies.
