### PR TITLE
Fix componentState

### DIFF
--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -58,7 +58,7 @@ void Prefab::reinit()
     std::cout << "VisualInitVisitor" << std::endl;
     execute<VisualInitVisitor>(nullptr);
 
-    m_componentstate = sofa::core::objectmodel::ComponentState::Valid;
+    d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
 }
 
 void Prefab::doReInit()


### PR DESCRIPTION
there was 3 different componentstates in SOFA before, it's been unified recently.
m_componentstate and d_componentstate dissapear, and we keep d_componentState.