### PR TITLE
Remove prefab init test

### DIFF
--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -23,7 +23,6 @@ void Prefab::init()
 {
     reinit();
     Inherit1::init(sofa::core::ExecParams::defaultInstance());
-    m_is_initialized = true;
 }
 
 void PrefabFileEventListener::fileHasChanged(const std::string &filename)

--- a/Plugin/src/SofaPython3/Prefab.h
+++ b/Plugin/src/SofaPython3/Prefab.h
@@ -48,6 +48,5 @@ public:
 
     PrefabFileEventListener m_filelistener;
     DataCallback m_datacallback;
-    bool m_is_initialized {false};
 };
 }  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -68,16 +68,10 @@ public:
 
 void Prefab_Trampoline::doReInit()
 {
-    if (!m_is_initialized) {
-        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Loading);
-        msg_warning(this) << "Prefab instantiated. Check for required prefab parameters to fully populate";
-        return;
-    }
-    try{
+    try {
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
         PYBIND11_OVERLOAD(void, Prefab, doReInit, );
-    } catch (std::exception& e)
-    {
+    } catch (std::exception& e) {
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
         msg_error(this) << e.what();
     }


### PR DESCRIPTION
@damienmarchal in the end I had to remove this feature:
This init test was used to determine whether the prefab had its parameters set (if `__init__` had been called and already returned), and the condition in `Binding_Prefab.cpp` guaranteed that the python's `doReInit()` wasn't called unless those parameters were properly added. (the purpose of this is to be able to hide the python exception thrown from not finding the parameters attributes in the prefab, and replace the exception messages with a cleaner warning, telling the user to check the required params on the prefab.)

This worked alright, except for prefabs WITHOUT parameters. those would never call `doReInit()` since this function is normally triggered when a parameter changes. since there's no parameter, there's no reInit.

Thus we need to find a different way of checking whether the `__init__` function has been called or not. I was thinking maybe in a decorator.

Ideally we want to set the initialized flag on the prefab *right after* we exit the `__init__` function, but that's not possible as is. maybe with a decorator?