### PR TITLE
Fix PythonFactory for Prefab Links

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -91,6 +91,7 @@ namespace sofa {
 
             class SOFAPYTHON3_API DataLink : public Data<PrefabLink>
             {
+            public:
                 typedef Data<PrefabLink> Inherit;
 
                 DataLink( const std::string& helpMsg="", bool isDisplayed=true, bool isReadOnly=false )
@@ -154,6 +155,15 @@ namespace sofa {
             };
 
         }
+    }
+    namespace defaulttype
+    {
+        template <>
+        struct DataTypeName<core::objectmodel::PrefabLink>
+        {
+            static const char* name() { return "PrefabLink"; }
+        };
+
     }
 }
 

--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -437,16 +437,14 @@ bool PythonFactory::registerDefaultTypes()
     // helper vector style containers
     std::string containers[] = {"vector"};
 
-    // PrefabLink
-    PythonFactory::registerType<sofa::core::objectmodel::PrefabLink>("PrefabLink");
-    PythonFactory::registerType<sofa::core::objectmodel::PrefabLink>("Link");
-
     // Scalars
     PythonFactory::registerType<std::string>("string");
     PythonFactory::registerType<float>("float");
     PythonFactory::registerType<double>("double");
     PythonFactory::registerType<bool>("bool");
     PythonFactory::registerType<int>("int");
+
+    PythonFactory::registerType<sofa::core::objectmodel::PrefabLink>("Link");
 
     // vectors
     PythonFactory::registerType<sofa::defaulttype::Vec2d>("Vec2d");

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.cpp
@@ -11,12 +11,12 @@ using sofa::core::objectmodel::PrefabLink;
 namespace sofapython3
 {
 
-py::str getTargetPath(PrefabLink& link)
+py::str getTargetPath(const PrefabLink& link)
 {
     return link.getTargetPath();
 }
 
-py::object getTargetBase(PrefabLink& link)
+py::object getTargetBase(const PrefabLink& link)
 {
     auto base = link.getTargetBase().get();
     if (base)
@@ -38,6 +38,17 @@ py::str DataLink::__repr__()
     return py::repr(convertToPython(this));
 }
 
+py::str DataLink::getTargetPath()
+{
+    return sofapython3::getTargetPath(reinterpret_cast<sofa::core::objectmodel::DataLink*>(this)->getValue());
+}
+
+py::object DataLink::getTargetBase()
+{
+    return sofapython3::getTargetBase(reinterpret_cast<sofa::core::objectmodel::DataLink*>(this)->getValue());
+}
+
+
 void moduleAddDataLink(py::module &m)
 {
     py::class_<PrefabLink, std::unique_ptr<PrefabLink, py::nodelete>> l(m, "PrefabLink");
@@ -49,12 +60,14 @@ void moduleAddDataLink(py::module &m)
 
     py::class_<DataLink, BaseData, std::unique_ptr<DataLink, py::nodelete>> d(m, "DataLink");
 
-    PythonFactory::registerType("DataLink", [](BaseData* data) -> py::object {
+    PythonFactory::registerType("PrefabLink", [](BaseData* data) -> py::object {
         return py::cast(reinterpret_cast<DataLink*>(data));
     });
 
     d.def("__repr__",&DataLink::__repr__);
     d.def("__str__", &DataLink::__str__);
+    d.def("getTargetBase", &DataLink::getTargetBase);
+    d.def("getTargetPath", &DataLink::getTargetPath);
 }
 
 }  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.cpp
@@ -48,6 +48,11 @@ py::object DataLink::getTargetBase()
     return sofapython3::getTargetBase(reinterpret_cast<sofa::core::objectmodel::DataLink*>(this)->getValue());
 }
 
+void DataLink::setTargetPath(const std::string& targetPath)
+{
+    reinterpret_cast<sofa::core::objectmodel::DataLink*>(this)->read(targetPath);
+}
+
 
 void moduleAddDataLink(py::module &m)
 {
@@ -68,6 +73,7 @@ void moduleAddDataLink(py::module &m)
     d.def("__str__", &DataLink::__str__);
     d.def("getTargetBase", &DataLink::getTargetBase);
     d.def("getTargetPath", &DataLink::getTargetPath);
+    d.def("setTargetPath", &DataLink::setTargetPath);
 }
 
 }  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.h
@@ -16,6 +16,8 @@ class DataLink : public BaseData
 public:
     py::str __str__();
     py::str __repr__();
+    py::str getTargetPath();
+    py::object getTargetBase();
 };
 
 }  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataLink.h
@@ -18,6 +18,7 @@ public:
     py::str __repr__();
     py::str getTargetPath();
     py::object getTargetBase();
+    void setTargetPath(const std::string& targetPath);
 };
 
 }  // namespace sofapython3


### PR DESCRIPTION
The PrefabLink-typed datafields retrieved using getattr on Base were returning Sofa.Core.Data instead of Sofa.Core.DataLink. Also added convenience functions getLinkedPath / getLinkedBase in DataLink binding