### PR TITLE
Improve syntax for Prefabs

### DIFF
--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -187,7 +187,18 @@ class Prefab(Sofa.Core.RawPrefab):
 
         self.setName(str(self.__class__.__name__))
         self.addData("prefabname", value=type(self).__name__, type="string", group="Infos", help="Name of the prefab")
-        self.addData("docstring", value=self.__doc__, type="string", group="Infos", help="Name of the prefab")
+        self.addData("docstring", value=self.__doc__, type="string", group="Infos", help="Documentation of the prefab")
+        # args[0] should be the parent node. it has to be added NOW (before creating prefabParams) so that the links can be resolved before calling doReInit()
+        if issubclass(type(args[0]), Sofa.Core.Node):
+            args[0].addChild(self)
+        # Prefab parameters must be created in a dedicated function so that it can be called HERE (after the context is set, and before calls to doReInit()
+        
+        if hasattr(self, "properties"):
+            docstring = ""
+            for p in self.properties:
+                self.addPrefabParameter(name=p['name'], type=p['type'], help=p['help'], default=kwargs.get(p['name'], p['default']))
+                self.__doc__ = self.__doc__ + "\n:param " + p['name'] + ": " + p['help'] + ", defaults to " + p['default'] + '\n:type ' + p['name'] + ": " + p['type'] + "\n\n"
+                self.docstring.value = self.__doc__
         self.init()
 
 def msg_error(target, message):


### PR DESCRIPTION
Prefab properties aren't added using addPrefabParameter but using a list of dict in self.__dict__.
The properties list is then parsed in the initializer of Sofa.Prefab class to reconstruct the prefabParameters

Examples are better than words so, here's a BEFORE / AFTER prefab example from STLIB:

*before:*
```py
# -*- coding: utf-8 -*-
import Sofa
from splib import SofaPrefab
from splib.objectmodel import SofaPrefab, SofaObject
from stlib.scene import Node
from stlib.visuals import VisualModel

class ElasticMaterialObject(Sofa.Prefab):
    def __init__(self, *args, **kwargs):
        Sofa.Prefab.__init__(self, *args, **kwargs)

    def createParams(self, *args, **kwargs):
        self.addPrefabParameter(name="volumeMeshFileName", type="string", help="The volume topology of this elastic material object", default=kwargs.get("volumeMeshFileName", ''))
        self.addPrefabParameter(name="surfaceMeshFileName", type="string", help="The surface topology of this elastic material object", default=kwargs.get("surfaceMeshFileName", ''))
        self.addPrefabParameter(name="rotation", type="Vec3d", help="Initial Rotation of this elastic material object", default=kwargs.get("rotation", [0,0,0]))
        self.addPrefabParameter(name="translation", type="Vec3d", help="Initial Translation of this elastic material object", default=kwargs.get("translation", [0,0,0]))
        self.addPrefabParameter(name="scale", type="Vec3d", help="Initial Scaling of this elastic material object", default=kwargs.get("scale", [1.0,1.0,1.0]))

        self.addPrefabParameter(name="collisionMesh", type="Link", help="The mesh file to use for collision", default=kwargs.get("collisionMesh", ''))
        self.addPrefabParameter(name="withConstraints", type="bool", help="Enables the use of constraints on this prefab (provided that you have a compatible solver and animation loop in your scene)", default=kwargs.get("withConstraints", True))
        
        self.addPrefabParameter(name="surfaceColor", type="Vec3d", help="The material color for the mesh visualization", default=kwargs.get("surfaceColor", [1.0, 1.0, 1.0]))
        
        self.addPrefabParameter(name="poissonRatio", type="double", help="Poisson ratio for the object", default=kwargs.get("poissonRatio", 0.3))
        self.addPrefabParameter(name="youngModulus", type="double", help="Young's modulus of this object", default=kwargs.get("youngModulus", 18000))
        self.addPrefabParameter(name="totalMass", type="double", help="the mass of the object, distributed evenly on the volume's nodes", default=kwargs.get("totalMass", 1.0))
        self.addPrefabParameter(name="solverName", type="Link", help="the name of the solver", default=kwargs.get("solveName", "no_solver"))


    def doReInit(self):
        # [....]
        pass
```

*after:*
```py
# -*- coding: utf-8 -*-
import Sofa
from splib import SofaPrefab
from splib.objectmodel import SofaPrefab, SofaObject
from stlib.scene import Node
from stlib.visuals import VisualModel

class ElasticMaterialObject(Sofa.Prefab):

    properties = [
        { 'name': "volumeMeshFileName",  'type': "string", 'help': "The volume topology of this elastic material object", 'default': '' },
        { 'name': "surfaceMeshFileName", 'type': "string", 'help': "The surface topology of this elastic material object", 'default': '' },
        { 'name': "rotation",            'type': "Vec3d",  'help': "Initial Rotation of this elastic material object", 'default': [0,0,0] },
        { 'name': "translation",         'type': "Vec3d",  'help': "Initial Translation of this elastic material object", 'default': [0,0,0] },
        { 'name': "scale",               'type': "Vec3d",  'help': "Initial Scaling of this elastic material object", 'default': [1.0,1.0,1.0] },

        { 'name': "collisionMesh",       'type': "Link",   'help': "The mesh file to use for collision", 'default': '' },
        { 'name': "withConstraints",     'type': "bool",   'help': "Enables the use of constraints on this prefab (provided that you have a compatible solver and animation loop in your scene)", 'default': True },
        
        { 'name': "surfaceColor",        'type': "Vec3d",  'help': "The material color for the mesh visualization", 'default': [1.0, 1.0, 1.0] },
        
        { 'name': "poissonRatio",        'type': "double", 'help': "Poisson ratio for the object", 'default': 0.3 },
        { 'name': "youngModulus",        'type': "double", 'help': "Young's modulus of this object", 'default': 18000 },
        { 'name': "totalMass",           'type': "double", 'help': "the mass of the object, distributed evenly on the volume's nodes", 'default': 1.0 },
        { 'name': "solverName",          'type': "Link",   'help': "the name of the solver", 'default': "no_solver"}
    ]
    
    def __init__(self, *args, **kwargs):
        Sofa.Prefab.__init__(self, *args, **kwargs)

        
    def doReInit(self):
        # [....]
        pass
```

In addition, a sphinx-style docstring is generated, and assigned both to the docstring datafield of the prefab, and to self.__doc__ so that it is accessible in its standard place in python 