### PR TITLE
✨ ADD TypeConversionEngine + inputs / outputs getters

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -93,12 +93,35 @@ namespace sofapython3
             try {
                 fct();
                 return;
-            } catch (std::exception& /*e*/) {
-                throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type");
+            } catch (std::exception& e) {
+                throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type\n" + e.what());
             }
         }
         throw py::type_error(this->getName() + " has no update() method.");
     }
+
+    py::list PyDataEngine::inputs()
+    {
+        py::list list;
+        auto fields = getDataFields();
+        auto it = std::remove_if(fields.begin(), fields.end(), [&](const auto & data){ return data->getGroup() != "Inputs"; });
+        fields.erase(it, fields.end());
+        for(auto i : fields)
+            list.append(PythonFactory::toPython(i));
+        return list;
+    }
+
+    py::list PyDataEngine::outputs()
+    {
+        py::list list;
+        auto fields = getDataFields();
+        auto it = std::remove_if(fields.begin(), fields.end(), [&](const auto & data){ return data->getGroup() != "Inputs"; });
+        fields.erase(it, fields.end());
+        for(auto i : fields)
+            list.append(PythonFactory::toPython(i));
+        return list;
+    }
+
 
     void moduleAddDataEngine(pybind11::module &m)
     {
@@ -133,6 +156,8 @@ namespace sofapython3
 
         f.def("addInput", &PyDataEngine::addInput, sofapython3::doc::dataengine::addInput);
         f.def("addOutput", &PyDataEngine::addOutput, sofapython3::doc::dataengine::addOutput);
+        f.def("inputs", &PyDataEngine::inputs);
+        f.def("outputs", &PyDataEngine::outputs);
     }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
@@ -50,6 +50,9 @@ public:
     void init() override;
     void doUpdate() override;
 
+    py::list inputs();
+    py::list outputs();
+
     PyDataEngine();
     ~PyDataEngine() override;
 

--- a/splib/__init__.py
+++ b/splib/__init__.py
@@ -78,3 +78,20 @@ def FunctionToPrefab(f):
             selfnode.init()
             return selfnode
         return SofaPrefabF
+
+    
+class TypeConversionEngine(Sofa.Core.DataEngine):
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.DataEngine.__init__(self, *args, **kwargs)
+        print(kwargs.get("dstType"))
+        self.addData(name="dst", type=kwargs.get("dstType"))
+        self.addOutput(self.dst)
+
+    def update(self):
+        for i in range(0,len(self.inputs())):
+            self.dst.value = self.__getattr__(self.inputs()[i].getName() + "_func")(self.inputs()[-1])
+
+    def addDataConversion(self, d, f):
+        data = self.addData(name=d.getOwner().getName() + "_" + d.getName(), value=d)
+        self.addInput(data)
+        self.__setattr__(data.getName() + "_func", f)


### PR DESCRIPTION
I was quite convinced that I already pull requested this feature, along with some resizing methods on DataContainer, but the feature seems to have been lost.
So here it goes:

This PR introduces a TypeConversionEngine class in splib, which inherits DataEngine, and converts incompatible types using a conversion function passed through its method addDataconversion()

This engine is used in SofaQtQuick to allow linkage of incompatible types in an easy and repeatable way without having to manually write a whole DataEngine class and import it in the scene graph.