### PR TITLE
Fix compilation with MSVC

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -84,6 +84,29 @@ namespace sofa {
                     return in;
                 }
 
+                inline bool operator ==(const PrefabLink& value) const
+                {
+                    if (getTargetBase())
+                    {
+                        if (value.getTargetBase())
+                            return getTargetBase() == value.getTargetBase();
+                        else
+                            return getTargetBase()->getPathName() == value.getTargetPath();
+                    }
+                    else
+                    {
+                        if (value.getTargetBase())
+                            return getTargetPath() == value.getTargetBase()->getPathName();
+                        else
+                            return getTargetPath() == value.getTargetPath();
+                    }
+                }
+
+                inline bool operator !=(const PrefabLink& value) const
+                {
+                    return !(*this == value);
+                }
+
             private:
                 Base::SPtr m_targetBase { nullptr };
                 std::string m_targetPath {""};

--- a/bindings/SofaExporter/CMakeLists.txt
+++ b/bindings/SofaExporter/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(SofaExporter REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    MODULE_NAME  Exporter
+    MODULE_NAME  SofaExporter
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaExporter SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/SofaExporter/CMakeLists.txt
+++ b/bindings/SofaExporter/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(SofaExporter REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    MODULE_NAME  SofaExporter
+    MODULE_NAME  Exporter
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaExporter SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/SofaExporter/tests/tests/STLExporter.py
+++ b/bindings/SofaExporter/tests/tests/STLExporter.py
@@ -7,5 +7,5 @@ import numpy
 
 class Test(unittest.TestCase):
     def test_STLExporter(self):
-        import SofaExporter
+        import Exporter
         Sofa.Helper.msg_error("Not implemented yet")


### PR DESCRIPTION
- PrefabLink needed == and != operators
~~- SofaExporter module name has been changed to Exporter to avoid collision with SofaExporter when generated the .lib file. (and all other bindings module does not have Sofa in their names anyway)~~