### PR TITLE
[CMake] Use sofa_add_plugin to make SofaPython3 deactivable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,10 +115,11 @@ if (APPLE)
     set(CMAKE_BUILD_RPATH "/Applications/Xcode.app/Contents/Developer/Library/Frameworks")
 endif()
 
-add_subdirectory(Plugin)
-add_subdirectory(bindings)
-add_subdirectory(examples)
-add_subdirectory(docs)
+find_package(SofaFramework REQUIRED)
+sofa_add_plugin(Plugin SofaPython3 ON)
+sofa_add_plugin(bindings SofaPython3_Bindings ON)
+sofa_add_plugin(examples SofaPython3_Examples ON)
+sofa_add_plugin(docs SofaPython3_Docs ON)
 
 SP3_add_python_package(
     SOURCE_DIRECTORY


### PR DESCRIPTION
TODO: uncomment this line in SOFA: https://github.com/sofa-framework/sofa/blob/master/applications/plugins/CMakeLists.txt#L6