### PR TITLE
[SofaPython3 ]Fix windows compilation when compiling out-of-tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ if (APPLE)
     set(CMAKE_BUILD_RPATH "/Applications/Xcode.app/Contents/Developer/Library/Frameworks")
 endif()
 
+if(MSVC)
+    #define BOOST_ALL_DYN_LINK needed for dynamic linking with boost libraries
+    add_definitions(-DBOOST_ALL_DYN_LINK)
+endif()
+
 add_subdirectory(Plugin)
 add_subdirectory(bindings)
 add_subdirectory(examples)


### PR DESCRIPTION
The needed boost preprocessor macro BOOST_ALL_DYN_LINK is not propagated from SOFA (as it is defined in its global CMakeLists)