### PR TITLE
[bindings] Fix missing plugins for forcefield tests

### DIFF
--- a/bindings/Sofa/tests/Core/ForceField.py
+++ b/bindings/Sofa/tests/Core/ForceField.py
@@ -40,10 +40,10 @@ def createParticle(node, node_name, use_implicit_scheme, use_iterative_solver):
 
 
 def rssffScene(use_implicit_scheme=True, use_iterative_solver=True):
-    SofaRuntime.importPlugin("SofaSparseSolver")
-    SofaRuntime.importPlugin("SofaExplicitOdeSolver")
-    SofaRuntime.importPlugin("SofaImplicitOdeSolver")
     node = Sofa.Core.Node("root")
+    node.addObject("RequiredPlugin", name="SofaSparseSolver")
+    node.addObject("RequiredPlugin", name="SofaExplicitOdeSolver")
+    node.addObject("RequiredPlugin", name="SofaImplicitOdeSolver")
     node.gravity = [0, -10, 0]
     createParticle(node, "particle", use_implicit_scheme, use_iterative_solver)
     return node

--- a/bindings/Sofa/tests/Core/PythonRestShapeForceField.py
+++ b/bindings/Sofa/tests/Core/PythonRestShapeForceField.py
@@ -38,8 +38,9 @@ def RestShapeObject(impl, name="unnamed", position=[]):
         return node
  
 def createScene(node):
+        node.addObject("RequiredPlugin", name="SofaImplicitOdeSolver")
         node.addObject("DefaultAnimationLoop", name="loop")
-        node.addObject("EulerImplicit")
+        node.addObject("EulerImplicitSolver")
         node.addObject("CGLinearSolver", tolerance=1e-12, threshold=1e-12)
         
         a=node.addChild( RestShapeObject( MyForceField("customFF", ks=5.0) , name="python", position=[[i-10.0, 0, 0] for i in range(100)] ) )


### PR DESCRIPTION
@ScheiklP reported a failing test in `PythonRestShapeForceField.py`


```
[ RUN      ] SofaPython3/Sofa.all_tests/62_Sofa_Core_PythonRestShapeForceField_test_example
======================================================================
ERROR: test_example (PythonRestShapeForceField.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "PythonRestShapeForceField.py", line 54, in test_example
    createScene(Sofa.Core.Node("root"))
  File "PythonRestShapeForceField.py", line 42, in createScene
    node.addObject("EulerImplicit")
ValueError: Object type EulerImplicit<> was not created  
The object is not in the factory.  


----------------------------------------------------------------------
Ran 1 test in 0.000s
```

This PR should fix it.