### PR TITLE
Fix cmake dependencies

### DIFF
--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -48,7 +48,7 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC "-DSOFA_HAVE_SOFAPYTHON3")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/>")
 target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include>")
 
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCore SofaSimulationGraph SofaHelper)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaDefaultType SofaSimulationCore SofaSimulationGraph SofaHelper)
 target_link_libraries(${PROJECT_NAME} PUBLIC  pybind11::module pybind11::embed)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME SofaPython3)

--- a/Plugin/src/SofaPython3/initModule.cpp
+++ b/Plugin/src/SofaPython3/initModule.cpp
@@ -51,6 +51,12 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include "PythonEnvironment.h"
 using sofapython3::PythonEnvironment;
 
+#include <sofa/core/init.h>
+#include <sofa/defaulttype/init.h>
+#include <sofa/simulation/init.h>
+#include <sofa/helper/init.h>
+#include <SofaSimulationGraph/init.h>
+
 extern "C" {
 
 SOFAPYTHON3_API void initExternalModule();
@@ -65,6 +71,12 @@ void initExternalModule()
     static bool first = true;
     if (first)
     {
+        sofa::core::init();
+        sofa::defaulttype::init();
+        sofa::simulation::core::init();
+        sofa::simulation::graph::init();
+        sofa::helper::init();
+
         PythonEnvironment::Init();
         first = false;
     }

--- a/bindings/BindingsConfig.cmake.in
+++ b/bindings/BindingsConfig.cmake.in
@@ -9,17 +9,20 @@ find_package(pybind11 CONFIG REQUIRED)
 # Required by Modules.SofaBaseTopology, Sofa.Components, Sofa.Core, Sofa.Helper, Sofa.Types, SofaExporter, SofaGui, SofaRuntime, SofaTypes
 find_package(SofaPython3 COMPONENTS Plugin)
 
-# Required by the bindings Modules.SofaBaseTopology, Sofa.Components, Sofa.Core, Sofa.Simulation
-find_package(SofaBase REQUIRED)
+# Required by the bindings Modules.SofaBaseTopology
+find_package(SofaBaseTopology REQUIRED)
 
 # Required by the bindings Sofa.Components, Sofa.Core, Sofa.Helper, Sofa.Simulation, Sofa.Types, SofaGui
 find_package(SofaFramework REQUIRED)
 
-# Required by the bindings Sofa.Core, Sofa.Simulation
+# Required by the bindings Sofa.Core, Sofa.Simulation, SofaRuntime
 find_package(SofaSimulation REQUIRED)
 
 # Required by the bindings SofaGui
 find_package(SofaGui REQUIRED)
+
+# Required by the bindings Sofa.Core
+find_package(SofaBaseVisual REQUIRED)
 
 #  Required by the bindings SofaExporter
 if(SP3_WITH_SOFAEXPORTER)

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
@@ -13,7 +13,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SparseGridTopology_doc.h
 )
 
-find_package(SofaBase REQUIRED)
+find_package(SofaBaseTopology REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
@@ -27,8 +27,10 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 
 #include <pybind11/pybind11.h>
 
-#include "Binding_RegularGridTopology.h"
-#include "Binding_SparseGridTopology.h"
+#include <SofaPython3/SofaBaseTopology/Binding_RegularGridTopology.h>
+#include <SofaPython3/SofaBaseTopology/Binding_SparseGridTopology.h>
+
+#include <SofaBaseTopology/initSofaBaseTopology.h>
 
 namespace py { using namespace pybind11; }
 
@@ -37,6 +39,8 @@ namespace sofapython3
 
 PYBIND11_MODULE(BaseTopology, m)
 {
+    sofa::component::initSofaBaseTopology();
+
     moduleAddRegularGridTopology(m);
     moduleAddSparseGridTopology(m);
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Components/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Components/CMakeLists.txt
@@ -16,5 +16,5 @@ SP3_add_python_module(
         MODULE_NAME  Components
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
-        DEPENDS      SofaCore SofaPython3::Plugin
+        DEPENDS      SofaCore SofaHelper SofaSimulationCore SofaPython3::Plugin
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Components/Submodule_Components.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Components/Submodule_Components.cpp
@@ -28,7 +28,6 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 
 #include <iostream>
 
-#include <sofa/core/init.h>
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::objectmodel::BaseObjectDescription;
 using sofa::core::ObjectFactory;
@@ -42,6 +41,10 @@ using sofa::simulation::Node;
 #include <SofaPython3/DataHelper.h>
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
+
+#include <sofa/core/init.h>
+#include <sofa/helper/init.h>
+#include <sofa/simulation/init.h>
 
 namespace py = pybind11;
 using namespace py::literals;
@@ -63,6 +66,8 @@ PYBIND11_MODULE(Components, m)
 {
     // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
     sofa::core::init();
+    sofa::helper::init();
+    sofa::simulation::core::init();
 
     py::class_<FCreator> mm(m, "Creator");
     mm.def("__call__", [](FCreator& s, const py::args& args, const py::kwargs& kwargs){

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -67,9 +67,9 @@ if (NOT TARGET SofaPython3::Plugin)
 endif()
 
 find_package(SofaFramework REQUIRED)
-find_package(SofaBase REQUIRED)
-find_package(SofaCommon REQUIRED)
 find_package(SofaSimulation REQUIRED)
+find_package(SofaBaseVisual REQUIRED)
+find_package(SofaBaseUtils REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
@@ -77,5 +77,5 @@ SP3_add_python_module(
     MODULE_NAME  Core
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      SofaBase SofaCore SofaSimulation SofaCommon SofaPython3::Plugin
+    DEPENDS      SofaBaseUtils SofaCore SofaHelper SofaSimulationCore SofaDefaultType SofaBaseVisual SofaPython3::Plugin
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -52,9 +52,11 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Data/Binding_DataContainer.h>
 
 #include <sofa/core/init.h>
-#include <SofaBase/initSofaBase.h>
-#include <SofaCommon/initSofaCommon.h>
-#include <SofaSimulation/initSofaSimulation.h>
+#include <sofa/helper/init.h>
+#include <sofa/simulation/init.h>
+#include <sofa/defaulttype/init.h>
+#include <SofaBaseVisual/initSofaBaseVisual.h>
+#include <SofaBaseUtils/initSofaBaseUtils.h>
 
 namespace sofapython3
 {
@@ -64,9 +66,11 @@ PYBIND11_MODULE(Core, core)
 {
     // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
     sofa::core::init();
-    sofa::component::initSofaBase();
-    sofa::component::initSofaCommon();
-    sofa::initSofaSimulation();
+    sofa::helper::init();
+    sofa::simulation::core::init();
+    sofa::defaulttype::init();
+    sofa::component::initSofaBaseVisual();
+    sofa::component::initSofaBaseUtils(); // Needed to add "RequiredPlugin" components
 
     core.doc() = R"doc(
            Scene components

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
@@ -23,5 +23,5 @@ SP3_add_python_module(
     MODULE_NAME  Helper
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      SofaCore SofaPython3::Plugin
+    DEPENDS      SofaCore SofaHelper SofaPython3::Plugin
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -26,6 +26,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 ********************************************************************/
 
 #include <sofa/core/init.h>
+#include <sofa/helper/init.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaPython3/PythonEnvironment.h>
 #include <sofa/core/objectmodel/Base.h>
@@ -115,6 +116,7 @@ PYBIND11_MODULE(Helper, helper)
 {
     // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
     sofa::core::init();
+    sofa::helper::init();
 
     helper.doc() = R"doc(
            Utility functions

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/CMakeLists.txt
@@ -17,5 +17,5 @@ SP3_add_python_module(
         MODULE_NAME  Types
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
-        DEPENDS      SofaCore SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+        DEPENDS      SofaCore SofaDefaultType SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Submodule_Types.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Submodule_Types.cpp
@@ -26,6 +26,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 ********************************************************************/
 
 #include <sofa/core/init.h>
+#include <sofa/defaulttype/init.h>
 
 #include <SofaPython3/Sofa/Types/Binding_BoundingBox.h>
 
@@ -35,6 +36,7 @@ PYBIND11_MODULE(Types, types)
 {
     // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
     sofa::core::init();
+    sofa::defaulttype::init();
 
     types.doc() = R"doc(
            Default data types

--- a/bindings/Sofa/tests/Components/Components.py
+++ b/bindings/Sofa/tests/Components/Components.py
@@ -7,6 +7,7 @@ import unittest
 class Test(unittest.TestCase):
     def test_component_creation(self):
         root = Sofa.Core.Node("rootNode")
+        root.addObject('RequiredPlugin', name='SofaBaseMechanics')
 
         c = Sofa.Components.MechanicalObject(root, name="dofs")
         self.assertTrue(c.name.value == "dofs")

--- a/bindings/Sofa/tests/Core/ForceField.py
+++ b/bindings/Sofa/tests/Core/ForceField.py
@@ -40,10 +40,10 @@ def createParticle(node, node_name, use_implicit_scheme, use_iterative_solver):
 
 
 def rssffScene(use_implicit_scheme=True, use_iterative_solver=True):
-    SofaRuntime.importPlugin("SofaSparseSolver")
-    SofaRuntime.importPlugin("SofaExplicitOdeSolver")
-    SofaRuntime.importPlugin("SofaImplicitOdeSolver")
     node = Sofa.Core.Node("root")
+    node.addObject("RequiredPlugin", name="SofaSparseSolver")
+    node.addObject("RequiredPlugin", name="SofaExplicitOdeSolver")
+    node.addObject("RequiredPlugin", name="SofaImplicitOdeSolver")
     node.gravity = [0, -10, 0]
     createParticle(node, "particle", use_implicit_scheme, use_iterative_solver)
     return node

--- a/bindings/Sofa/tests/Core/PythonRestShapeForceField.py
+++ b/bindings/Sofa/tests/Core/PythonRestShapeForceField.py
@@ -38,8 +38,9 @@ def RestShapeObject(impl, name="unnamed", position=[]):
         return node
  
 def createScene(node):
+        node.addObject("RequiredPlugin", name="SofaImplicitOdeSolver")
         node.addObject("DefaultAnimationLoop", name="loop")
-        node.addObject("EulerImplicit")
+        node.addObject("EulerImplicitSolver")
         node.addObject("CGLinearSolver", tolerance=1e-12, threshold=1e-12)
         
         a=node.addChild( RestShapeObject( MyForceField("customFF", ks=5.0) , name="python", position=[[i-10.0, 0, 0] for i in range(100)] ) )

--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
@@ -28,6 +28,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include <pybind11/pybind11.h>
 
 #include <sofa/gui/Main.h>
+#include <sofa/core/init.h>
 
 #include "Binding_BaseGui.h"
 #include "Binding_GUIManager.h"
@@ -64,6 +65,7 @@ PYBIND11_MODULE(Gui, m) {
     // This is needed to make sure the GuiMain library (libSofaGuiMain.so) is correctly
     // linked since the GUIs are statically created during the load of the library.
     sofa::gui::initMain();
+    sofa::core::init();
 
     moduleAddBaseGui(m);
     moduleAddGuiManager(m);

--- a/bindings/SofaRuntime/CMakeLists.txt
+++ b/bindings/SofaRuntime/CMakeLists.txt
@@ -25,7 +25,7 @@ SP3_add_python_module(
         MODULE_NAME  SofaRuntime
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
-        DEPENDS      SofaSimulationGraph SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+        DEPENDS      SofaCore SofaHelper SofaSimulationCore SofaSimulationGraph SofaSimulationCommon SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
 )
 
 if(SP3_BUILD_TEST)

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
@@ -28,9 +28,6 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include <pybind11/eval.h>
 namespace py = pybind11;
 
-#include <sofa/simulation/Node.h>
-using sofa::simulation::Node;
-
 #include <SofaSimulationGraph/DAGSimulation.h>
 using sofa::simulation::graph::DAGSimulation ;
 using sofa::simulation::Simulation;
@@ -56,14 +53,7 @@ using sofapython3::SceneLoaderPY3;
 #include <SofaSimulationCommon/init.h>
 #include <SofaSimulationGraph/init.h>
 
-#include <sofa/helper/system/FileRepository.h>
-
-#include <SofaPython3/Sofa/Core/Binding_Base.h>
-#include <SofaPython3/Sofa/Core/Binding_Node.h>
-
 #include "Timer/Submodule_Timer.h"
-
-#include <SofaPython3/DataHelper.h>
 
 #include <sofa/helper/logging/MessageDispatcher.h>
 #include <sofa/helper/logging/ConsoleMessageHandler.h>
@@ -71,6 +61,12 @@ using sofapython3::SceneLoaderPY3;
 using sofa::helper::logging::MessageDispatcher;
 using sofa::helper::logging::MainPerComponentLoggingMessageHandler;
 using sofa::helper::logging::MainConsoleMessageHandler;
+
+#include <sofa/core/init.h>
+#include <sofa/helper/init.h>
+#include <sofa/simulation/init.h>
+#include <SofaSimulationGraph/init.h>
+#include <SofaSimulationCommon/init.h>
 
 namespace sofapython3
 {
@@ -116,6 +112,13 @@ PYBIND11_MODULE(SofaRuntime, m) {
                    SofaRuntime.importPlugin("SofaSparseSolver")
 
               )doc";
+
+    // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
+    sofa::core::init();
+    sofa::helper::init();
+    sofa::simulation::core::init();
+    sofa::simulation::graph::init();
+    sofa::simulation::common::init();
 
     // Add the plugin directory to PluginRepository
     const std::string& pluginDir = Utils::getExecutableDirectory();

--- a/bindings/SofaTypes/CMakeLists.txt
+++ b/bindings/SofaTypes/CMakeLists.txt
@@ -28,7 +28,7 @@ SP3_add_python_module(
     MODULE_NAME  SofaTypes
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      SofaCore SofaDefaultType SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+    DEPENDS      SofaDefaultType SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
 )
 
 if(SP3_BUILD_TEST)

--- a/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Vec.cpp
+++ b/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Vec.cpp
@@ -27,7 +27,6 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 
 #include "Binding_Vec.h"
 #include <functional>
-#include <type_traits>
 #include <pybind11/operators.h>
 
 #define BINDING_VEC_MAKE_NAME(N, T)                                            \

--- a/bindings/SofaTypes/src/SofaPython3/SofaTypes/Module_SofaTypes.cpp
+++ b/bindings/SofaTypes/src/SofaPython3/SofaTypes/Module_SofaTypes.cpp
@@ -27,19 +27,16 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 
 
 #include <pybind11/pybind11.h>
-//#include <src/pybind/Binding_BoundingBox.h>
-//#include <src/pybind/Binding_Color.h>
-//#include <src/pybind/Binding_Frame.h>
 #include <SofaPython3/SofaTypes/Binding_Mat.h>
 #include <SofaPython3/SofaTypes/Binding_Quat.h>
 #include <SofaPython3/SofaTypes/Binding_Vec.h>
+#include <sofa/defaulttype/init.h>
 
 /// The first parameter must be named the same as the module file to load.
 PYBIND11_MODULE(SofaTypes, m) {
-//  moduleAddBoundingBox(m);
-//  moduleAddColor(m);
-//  moduleAddFrame(m);
-  moduleAddMat(m);
-  moduleAddQuat(m);
-  moduleAddVec(m);
+    sofa::defaulttype::init();
+
+    moduleAddMat(m);
+    moduleAddQuat(m);
+    moduleAddVec(m);
 }


### PR DESCRIPTION
Following SOFA's [pluginization](https://github.com/sofa-framework/sofa/issues/1527)  , this PR clean up modules dependencies.