### PR TITLE
[cmake] Fix compilation issue on MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,6 +70,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_PREFIX_PATH=$SOFA_ROOT/lib/cmake
           -DCMAKE_BUILD_TYPE=Release
+          -DPYTHON_EXECUTABLE=$(which python)
           .
           && ninja && ninja install
           && echo ${CCACHE_BASEDIR}


### PR DESCRIPTION
Fix an issue on MacOS where the python modules where bundles instead of shared libraries, hence creating a link error during compilation. See https://ci.inria.fr/sofa-ci-dev/job/sofa-custom/CI_CONFIG=mac_clang-3.5,CI_TYPE=release/932/console for the error log.
