### PR TITLE
[cmake] Export SP3 cmake tools for usage in external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,6 @@ if(PYTHON_EXECUTABLE)
         set(python_version_flag "EXACT")
     endif()
 endif()
-message("${PROJECT_NAME}: Searching Python ${python_version} ${python_version_flag}")
 find_package(Python ${python_version} ${python_version_flag} COMPONENTS Interpreter Development REQUIRED)
 set(PYTHON_VERSION ${Python_VERSION})
 set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
@@ -190,6 +189,12 @@ sofa_create_package(
     PACKAGE_VERSION ${PROJECT_VERSION}
     RELOCATABLE "plugins"
     )
+
+install(FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/CMake/SofaPython3Tools.cmake"
+    DESTINATION lib/cmake/SofaPython3
+    COMPONENT headers
+)
 
 if (SP3_LINK_TO_USER_SITE AND SP3_PYTHON_PACKAGES_LINK_DIRECTORY)
     file(GLOB directories RELATIVE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${SP3_PYTHON_PACKAGES_DIRECTORY}" "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${SP3_PYTHON_PACKAGES_DIRECTORY}/*")

--- a/Plugin/PluginConfig.cmake.in
+++ b/Plugin/PluginConfig.cmake.in
@@ -5,7 +5,6 @@
 find_package(pybind11 CONFIG REQUIRED)
 find_package(SofaFramework REQUIRED)
 find_package(SofaSimulation REQUIRED)
-find_package(SofaGeneral REQUIRED)
 
 # If we are importing this config file and the target is not yet there this is indicating that
 # target is an imported one. So we include it

--- a/SofaPython3Config.cmake.in
+++ b/SofaPython3Config.cmake.in
@@ -4,6 +4,26 @@
 @PACKAGE_INIT@
 
 set(SP3_WITH_SOFAEXPORTER @SP3_WITH_SOFAEXPORTER@)
+set(SP3_PYTHON_PACKAGES_DIRECTORY @SP3_PYTHON_PACKAGES_DIRECTORY@)
+
+include("${CMAKE_CURRENT_LIST_DIR}/SofaPython3Tools.cmake")
+
+# Find Python3 executable and set PYTHON_EXECUTABLE before finding pybind11
+# to be sure that pybind11 relies on the right Python version
+set(python_version @PYBIND11_PYTHON_VERSION@)
+set(python_version_flag @python_version_flag@)
+
+find_package(Python ${python_version} ${python_version_flag} COMPONENTS Interpreter Development REQUIRED)
+
+set(PYTHON_VERSION ${Python_VERSION})
+set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+set(PYTHON_LIBRARIES ${Python_LIBRARIES})
+set(PYTHON_INCLUDE_DIRS ${Python_INCLUDE_DIRS})
+set(PYTHON_LIBRARY ${Python_LIBRARY})
+set(PYTHON_INCLUDE_DIR ${Python_INCLUDE_DIR})
+
+# Set the minimum pybind11 version to 2.3 (before that the pybind11::embed target did not exist)
+find_package(pybind11 2.3 CONFIG QUIET REQUIRED)
 
 if (SofaPython3_FIND_COMPONENTS)
         foreach(component ${SofaPython3_FIND_COMPONENTS})

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
@@ -17,8 +17,9 @@ find_package(SofaBaseTopology REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE_NAME Sofa
-    MODULE_NAME  SofaBaseTopology
+    PACKAGE      Bindings
+    MODULE       SofaBaseTopology
+    DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaBaseTopology SofaPython3::Plugin

--- a/bindings/Modules/src/SofaPython3/SofaDeformable/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaDeformable/CMakeLists.txt
@@ -22,8 +22,9 @@ find_package(SofaDeformable REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE_NAME Sofa
-    MODULE_NAME  SofaDeformable
+    PACKAGE      Bindings
+    MODULE       SofaDeformable
+    DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaBase SofaDeformable SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/Sofa/src/SofaPython3/Sofa/Components/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Components/CMakeLists.txt
@@ -12,8 +12,9 @@ find_package(SofaFramework REQUIRED)
 
 SP3_add_python_module(
         TARGET       ${PROJECT_NAME}
-        PACKAGE_NAME Sofa
-        MODULE_NAME  Components
+        PACKAGE      Bindings
+        MODULE       Components
+        DESTINATION  Sofa
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
         DEPENDS      SofaCore SofaHelper SofaSimulationCore SofaPython3::Plugin

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -77,8 +77,9 @@ find_package(SofaBaseUtils REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE_NAME Sofa
-    MODULE_NAME  Core
+    PACKAGE      Bindings
+    MODULE       Core
+    DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaBaseUtils SofaBaseCollision SofaCore SofaHelper SofaSimulationCore SofaDefaultType SofaBaseVisual SofaPython3::Plugin

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
@@ -19,8 +19,9 @@ find_package(SofaFramework REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE_NAME Sofa
-    MODULE_NAME  Helper
+    PACKAGE      Bindings
+    MODULE       Helper
+    DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaCore SofaHelper SofaPython3::Plugin

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
@@ -17,8 +17,9 @@ find_package(SofaSimulation REQUIRED)
 
 SP3_add_python_module(
         TARGET       ${PROJECT_NAME}
-        PACKAGE_NAME Sofa
-        MODULE_NAME  Simulation
+        PACKAGE      Bindings
+        MODULE       Simulation
+        DESTINATION  Sofa
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
         DEPENDS      SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3::Plugin

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/CMakeLists.txt
@@ -13,8 +13,9 @@ find_package(SofaFramework REQUIRED)
 
 SP3_add_python_module(
         TARGET       ${PROJECT_NAME}
-        PACKAGE_NAME Sofa
-        MODULE_NAME  Types
+        PACKAGE      Bindings
+        MODULE       Types
+        DESTINATION  Sofa
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
         DEPENDS      SofaCore SofaDefaultType SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/SofaExporter/CMakeLists.txt
+++ b/bindings/SofaExporter/CMakeLists.txt
@@ -14,7 +14,8 @@ find_package(SofaExporter REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    MODULE_NAME  SofaExporter
+    PACKAGE      Bindings
+    MODULE       SofaExporter
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaExporter SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/SofaGui/CMakeLists.txt
+++ b/bindings/SofaGui/CMakeLists.txt
@@ -17,8 +17,9 @@ find_package(SofaFramework REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE_NAME Sofa
-    MODULE_NAME  Gui
+    PACKAGE      Bindings
+    MODULE       Gui
+    DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaCore SofaGuiCommon SofaGuiMain SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/SofaRuntime/CMakeLists.txt
+++ b/bindings/SofaRuntime/CMakeLists.txt
@@ -21,8 +21,9 @@ SP3_add_python_package(
 
 SP3_add_python_module(
         TARGET       ${PROJECT_NAME}
-        PACKAGE_NAME SofaRuntime
-        MODULE_NAME  SofaRuntime
+        PACKAGE      Bindings
+        MODULE       SofaRuntime
+        DESTINATION  SofaRuntime
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
         DEPENDS      SofaCore SofaHelper SofaSimulationCore SofaSimulationGraph SofaSimulationCommon SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core

--- a/bindings/SofaTypes/CMakeLists.txt
+++ b/bindings/SofaTypes/CMakeLists.txt
@@ -24,8 +24,9 @@ find_package(SofaFramework REQUIRED)
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE_NAME SofaTypes
-    MODULE_NAME  SofaTypes
+    PACKAGE      Bindings
+    MODULE       SofaTypes
+    DESTINATION  SofaTypes
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
     DEPENDS      SofaDefaultType SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core


### PR DESCRIPTION
This PR will allow external projects (SOFA plugins) to use the SP3 cmake macros to set up their bindings.