### PR TITLE
[SofaBaseTopology] Fix binding entry point

### DIFF
--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
@@ -30,7 +30,7 @@ namespace py { using namespace pybind11; }
 namespace sofapython3
 {
 
-PYBIND11_MODULE(BaseTopology, m)
+PYBIND11_MODULE(SofaBaseTopology, m)
 {
     sofa::component::initSofaBaseTopology();
 


### PR DESCRIPTION
Fixes this error:

```
>>> import Sofa.SofaBaseTopology
[ERROR]   [PythonScript] ImportError: dynamic module does not define module export function (PyInit_SofaBaseTopology)
  File "<stdin>", line 1, in <module>
```