### PR TITLE
[Plugin] Change the initialization order of the Prefab

### DIFF
--- a/Plugin/src/SofaPython3/Prefab.cpp
+++ b/Plugin/src/SofaPython3/Prefab.cpp
@@ -43,9 +43,9 @@ using sofa::core::objectmodel::Event;
 
 void Prefab::init()
 {
-    reinit();
     Inherit1::init(sofa::core::ExecParams::defaultInstance());
     m_is_initialized = true;
+    reinit();
 }
 
 void PrefabFileEventListener::fileHasChanged(const std::string &filename)


### PR DESCRIPTION
Fixes https://github.com/sofa-framework/SofaPython3/issues/92

@damienmarchal Could you have a look and let me know if it safe enough to be backported in the v20.12 release?