### PR TITLE
[Bindings/SofaTypes] static_assert on cross()

### DIFF
--- a/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Vec.cpp
+++ b/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Vec.cpp
@@ -219,15 +219,8 @@ T addCross(T p)
 {
     p.def("cross", [](typename T::type& a, typename T::type& b)
     {
-            if constexpr (T::type::spatial_dimensions == 2 || T::type::spatial_dimensions == 3)
-            {
-                return sofa::type::cross(a, b);
-            }
-            else
-            {
-                // can only call cross with vec2 or vec3
-                return T();
-            }
+            static_assert(T::type::spatial_dimensions == 2 || T::type::spatial_dimensions == 3, "Cross product function can only be used with Vec2 and Vec3");
+            return sofa::type::cross(a, b);
     });
     return p;
 }


### PR DESCRIPTION
Add a static assert on addCross, if called with something else than Vec2 or Vec3.
Make the code clearer anyway.