### PR TITLE
[bindings] Upcast BaseContext topology getters

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseContext.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseContext.cpp
@@ -22,6 +22,7 @@
 #include <SofaPython3/Sofa/Core/Binding_BaseContext.h>
 #include <SofaPython3/PythonFactory.h>
 #include <sofa/core/BaseState.h>
+#include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
 #include <sofa/core/topology/Topology.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
@@ -54,9 +55,9 @@ void moduleAddBaseContext(py::module& m) {
     c.def("getRootContext", &BaseContext::getRootContext, "Get the root context of the graph");
     c.def("getState", &BaseContext::getState, "Mechanical Degrees-of-Freedom");
     c.def("getMechanicalState", &BaseContext::getMechanicalState, "Mechanical Degrees-of-Freedom");
-    c.def("getTopology", &BaseContext::getTopology, "Topology");
-    c.def("getMeshTopology", &BaseContext::getMeshTopology, "Mesh Topology (unified interface for both static and dynamic topologies)");
-    c.def("getMeshTopologyLink", &BaseContext::getMeshTopologyLink, "Mesh Topology (unified interface for both static and dynamic topologies)");
+    c.def("getTopology", [](BaseContext &self){sofa::core::objectmodel::BaseObject *topo = self.getTopology(); return topo;}, "Topology");
+    c.def("getMeshTopology",[](BaseContext &self){sofa::core::objectmodel::BaseObject *topo = self.getMeshTopology(); return topo;}, "Mesh Topology (unified interface for both static and dynamic topologies)");
+    c.def("getMeshTopologyLink", [](BaseContext &self){sofa::core::objectmodel::BaseObject *topo = self.getMeshTopologyLink(); return topo;}, "Mesh Topology (unified interface for both static and dynamic topologies)");
     c.def("getMass", &BaseContext::getMass, "Mass");
 
     c.def("__str__", [](const BaseContext & context) {std::ostringstream s; s << context; return s.str();}, "Get a string representation of the context.");


### PR DESCRIPTION
When trying to use self.getContext().getTopology() in a python forcefield, it crashes because BaseTopology is not explicitly wrapped. I've upcasted the getter functions with lambdas to return a BaseObject pointer. This seems to work fine and now the edges/triangles/etc can be reached from python.

Also there seems to be no difference at all between getMeshTopology and getMeshTopologyLink. Is this on purpose?