### PR TITLE
[bindings] Started Topology and BaseMeshTopology bindings

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseContext.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseContext.cpp
@@ -22,6 +22,7 @@
 #include <SofaPython3/Sofa/Core/Binding_BaseContext.h>
 #include <SofaPython3/PythonFactory.h>
 #include <sofa/core/BaseState.h>
+#include <sofa/core/objectmodel/BaseObject.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
 #include <sofa/core/topology/Topology.h>
 #include <sofa/core/topology/BaseMeshTopology.h>
@@ -55,8 +56,8 @@ void moduleAddBaseContext(py::module& m) {
     c.def("getState", &BaseContext::getState, "Mechanical Degrees-of-Freedom");
     c.def("getMechanicalState", &BaseContext::getMechanicalState, "Mechanical Degrees-of-Freedom");
     c.def("getTopology", &BaseContext::getTopology, "Topology");
-    c.def("getMeshTopology", &BaseContext::getMeshTopology, "Mesh Topology (unified interface for both static and dynamic topologies)");
-    c.def("getMeshTopologyLink", &BaseContext::getMeshTopologyLink, "Mesh Topology (unified interface for both static and dynamic topologies)");
+    c.def("getMeshTopology", &BaseContext::getMeshTopology, py::arg("SearchDirection") = BaseContext::SearchDirection::SearchUp, "Mesh Topology (unified interface for both static and dynamic topologies)");
+    c.def("getMeshTopologyLink", &BaseContext::getMeshTopologyLink, py::arg("SearchDirection") = BaseContext::SearchDirection::SearchUp, "Mesh Topology (unified interface for both static and dynamic topologies)");
     c.def("getMass", &BaseContext::getMass, "Mass");
 
     c.def("__str__", [](const BaseContext & context) {std::ostringstream s; s << context; return s.str();}, "Get a string representation of the context.");

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_BaseContext.h>
+#include <SofaPython3/PythonFactory.h>
+#include <sofa/core/BaseState.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/core/topology/Topology.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
+
+
+namespace py { using namespace pybind11; }
+
+using namespace sofa::core::objectmodel;
+using namespace sofa::core::topology;
+
+namespace sofapython3 {
+
+void moduleAddBaseMeshTopology(py::module& m) {
+    py::class_<BaseMeshTopology, Base, py_shared_ptr<BaseMeshTopology>> c (m, "BaseMeshTopology");
+}
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddBaseMeshTopology(pybind11::module &m);
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Topology.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Topology.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_BaseContext.h>
+#include <SofaPython3/PythonFactory.h>
+#include <sofa/core/BaseState.h>
+#include <sofa/core/objectmodel/BaseObject.h>
+#include <sofa/core/behavior/BaseMechanicalState.h>
+#include <sofa/core/topology/Topology.h>
+#include <sofa/core/topology/BaseMeshTopology.h>
+
+
+namespace py { using namespace pybind11; }
+
+using namespace sofa::core::objectmodel;
+using namespace sofa::core::topology;
+
+namespace sofapython3 {
+
+void moduleAddTopology(py::module& m) {
+    py::class_<Topology, Base, py_shared_ptr<Topology>> c (m, "Topology");
+}
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Topology.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Topology.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddTopology(pybind11::module &m);
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -38,6 +38,8 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseLink_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseData_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseCamera_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Topology.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseMeshTopology.h
 )
 
 set(SOURCE_FILES
@@ -63,6 +65,8 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_PythonScriptEvent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseLink.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Topology.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseMeshTopology.cpp
 )
 
 if (NOT TARGET SofaPython3::Plugin)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -39,6 +39,8 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Binding_Prefab.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseLink.h>
 #include <SofaPython3/Sofa/Core/Binding_PythonScriptEvent.h>
+#include <SofaPython3/Sofa/Core/Binding_Topology.h>
+#include <SofaPython3/Sofa/Core/Binding_BaseMeshTopology.h>
 
 #include <SofaPython3/Sofa/Core/Data/Binding_DataString.h>
 #include <SofaPython3/Sofa/Core/Data/Binding_DataLink.h>
@@ -134,6 +136,8 @@ PYBIND11_MODULE(Core, core)
     moduleAddNodeIterator(core);
     moduleAddPrefab(core);
     moduleAddBaseLink(core);
+    moduleAddTopology(core);
+    moduleAddBaseMeshTopology(core);
 }
 
 } ///namespace sofapython3


### PR DESCRIPTION
Hopefully this is a better way to fix #113. I don't have the time right now to fill the objects with their class-specific properties/methods, but the groundwork is now there for someone to add them as needed.

The following now works in a python forcefield:
```python
    def init(self):
        self.topology = self.getContext().getTopology()
        self.topology = self.getContext().getMeshTopology()
        self.topology = self.getContext().getMeshTopologyLink(Sofa.Core.BaseContext.SearchUp)
        print(self.topology.edges.array())
```