### PR TITLE
[cmake] CMake config was exporting the wrong python version

### DIFF
--- a/SofaPython3Config.cmake.in
+++ b/SofaPython3Config.cmake.in
@@ -11,7 +11,7 @@ include(SofaPython3Tools)
 
 # Find Python3 executable and set PYTHON_EXECUTABLE before finding pybind11
 # to be sure that pybind11 relies on the right Python version
-set(python_version @PYBIND11_PYTHON_VERSION@)
+set(python_version @PYTHON_VERSION@)
 set(python_version_flag @python_version_flag@)
 
 find_package(Python ${python_version} ${python_version_flag} COMPONENTS Interpreter Development REQUIRED)


### PR DESCRIPTION
The cmake configuration file was exporting the value we give to pybind11 (python 3.7) which is the minimum required. Since this value will be later on taken by an external cmake project as a strict version requirement, it will probably fail.

In a nutshell, the problem was:
1. cmake search for 3.7 -> finds 3.9 OK
2. Compilation of SP3 is done using 3.9
3. SofaPython3Config.cmake is exported with a python 3.7 requirement
4. External project is now required to use python 3.7, even tho SP3 was compiled using 3.9 