### PR TITLE
[Bindings] Fix compilation

### DIFF
--- a/Plugin/src/SofaPython3/PythonTestExtractor.cpp
+++ b/Plugin/src/SofaPython3/PythonTestExtractor.cpp
@@ -21,6 +21,7 @@
 #include <SofaPython3/PythonTestExtractor.h>
 #include <SofaPython3/PythonEnvironment.h>
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/system/FileSystem.h>
 #include <sofa/helper/StringUtils.h>
 #include <sofa/helper/system/SetDirectory.h>

--- a/bindings/Modules/tests/main.cpp
+++ b/bindings/Modules/tests/main.cpp
@@ -22,6 +22,7 @@
 #include <SofaPython3/PythonTestExtractor.h>
 #include <sofa/helper/Utils.h>
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseLink.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseLink.cpp
@@ -84,10 +84,8 @@ void moduleAddBaseLink(py::module& m)
     link.def("getHelp", &BaseLink::getHelp,  sofapython3::doc::baseLink::getHelp);
     link.def("setHelp", setHelp, sofapython3::doc::baseLink::setHelp);
 
-    link.def("getOwnerData", &BaseLink::getOwnerData, sofapython3::doc::baseLink::getOwnerData);
     link.def("getOwnerBase", getOwnerBase, sofapython3::doc::baseLink::getOwnerBase);
 
-    link.def("getLinkedData", &BaseLink::getLinkedData, sofapython3::doc::baseLink::getLinkedData);
     link.def("getLinkedBase", getLinkedBase, "index"_a = 0, sofapython3::doc::baseLink::getLinkedBase);
     link.def("setLinkedBase", &BaseLink::setLinkedBase, sofapython3::doc::baseLink::getLinkedBase);
 

--- a/bindings/Sofa/tests/Core/BaseLink.py
+++ b/bindings/Sofa/tests/Core/BaseLink.py
@@ -86,10 +86,8 @@ class Test(unittest.TestCase):
         mm  = root.addObject("BarycentricMapping", input="@/t1", output="@/t2")
         link_input = mm.findLink("input")
         self.assertEqual(link_input.getLinkedBase(0).getName(),"t1")
-        self.assertEqual(link_input.getLinkedData(0), None)
         link_output = mm.findLink("output")
         self.assertEqual(link_output.getLinkedBase(0).getName(),"t2")
-        self.assertEqual(link_output.getLinkedData(0), None)
         self.assertEqual(link_input.getOwnerBase().getName(), "BarycentricMapping")
         self.assertEqual(link_output.getOwnerBase().getName(), "BarycentricMapping")
 

--- a/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
+++ b/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
@@ -29,6 +29,7 @@ using sofapython3::PythonTestExtractor ;
 using sofapython3::PrintTo ;
 using std::string;
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
 using sofa::helper::logging::MessageDispatcher;
 using sofa::helper::logging::MainPerComponentLoggingMessageHandler;

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.cpp
@@ -27,6 +27,8 @@ using sofa::helper::AdvancedTimer;
 
 #include <stack>
 
+#include <sofa/helper/logging/Messaging.h>
+
 namespace sofapython3
 {
 

--- a/bindings/SofaRuntime/tests/PythonModule_SofaRuntime_test.cpp
+++ b/bindings/SofaRuntime/tests/PythonModule_SofaRuntime_test.cpp
@@ -29,6 +29,7 @@ using sofapython3::PythonTestExtractor ;
 using sofapython3::PrintTo ;
 using std::string;
 
+#include <sofa/helper/logging/Messaging.h>
 #include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
 using sofa::helper::logging::MessageDispatcher;
 using sofa::helper::logging::MainPerComponentLoggingMessageHandler;


### PR DESCRIPTION
2 functions from Link has been marked as deleted, so those two bindings are not relevant anymore (and does not compile anyway)