### PR TITLE
[ForceField] Changed python classes to specify template type

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
@@ -36,34 +36,6 @@ using namespace sofa::core::topology;
 
 namespace sofapython3 {
 
-std::vector<int> convertEdge(const BaseMeshTopology::Edge &edge)
-{
-    static std::vector<int> vector_edge{2, 0};
-    vector_edge.at(0) = edge[0];
-    vector_edge.at(1) = edge[1];
-    return vector_edge;
-}
-
-std::vector<int> convertTetra(const BaseMeshTopology::Tetra &tetra)
-{
-    static std::vector<int> vector_tetra{4, 0};
-    vector_tetra.resize(4);
-    for (int i = 0; i < 4; i++){
-        vector_tetra.at(i) = tetra[i];
-    }    
-    return vector_tetra;
-}
-
-std::vector<int> edgesInTetrahedron(const BaseMeshTopology::EdgesInTetrahedron &edges)
-{
-    static std::vector<int> vector_edges{6, 0};
-    vector_edges.resize(6);
-    for (int i = 0; i < 6; i++){
-        vector_edges.at(i) = edges[i];
-    }
-    return vector_edges;
-}
-
 void moduleAddBaseMeshTopology(py::module& m) {
     py::class_<BaseMeshTopology, Base, py_shared_ptr<BaseMeshTopology>> c (m, "BaseMeshTopology");
 
@@ -82,22 +54,40 @@ void moduleAddBaseMeshTopology(py::module& m) {
     c.def("getNbQuads", &BaseMeshTopology::getNbQuads);
     c.def("getNbTetras", &BaseMeshTopology::getNbTetras);
 
-    c.def("getEdge", [](BaseMeshTopology &self, int i){return convertEdge(self.getEdge(i));});
+    c.def("getEdge", 
+      [] (BaseMeshTopology &self, const sofa::Index & index) -> std::array<sofa::Index, 2> {
+          const auto & e = self.getEdge(index);
+          return {{e[0], e[1]}};
+      },
+      py::arg("index")
+    );
 
-    c.def("getLocalEdgesInTetrahedron", [](BaseMeshTopology &self, int i){return convertEdge(self.getLocalEdgesInTetrahedron(i));},
-    R"(
-        Returns for each index (between 0 and 5) the two vertex indices that are adjacent to that edge.
-        )");
+    c.def("getLocalEdgesInTetrahedron", 
+      [] (const BaseMeshTopology & self, const sofa::Index & index) -> std::array<sofa::Index, 2> {
+          const auto & e = self.getLocalEdgesInTetrahedron(index);
+          return {{e[0], e[1]}};
+      },
+      py::arg("index"),
+      "Returns for each index (between 0 and 5) the two vertex indices that are adjacent to that edge."
+    );
 
-    c.def("getEdgesInTetrahedron", [](BaseMeshTopology &self, int i){return edgesInTetrahedron(self.getEdgesInTetrahedron(i));},
-    R"(
-        Returns the set of edges adjacent to a given tetrahedron.
-        )");
+    c.def("getEdgesInTetrahedron", 
+      [] (BaseMeshTopology & self, const sofa::Index & index) -> std::array<sofa::Index, 6> {
+          const auto & e = self.getEdgesInTetrahedron(index);
+          return {{e[0], e[1], e[2], e[3], e[4], e[5]}};
+      },
+      py::arg("index"),
+      "Returns the set of edges adjacent to a given tetrahedron."
+    );
 
-    c.def("getTetrahedron", [](BaseMeshTopology &self, int i){return convertTetra(self.getTetrahedron(i));},
-    R"(
-        Returns the vertices of Tetrahedron at index i.
-        )");
+    c.def("getTetrahedron", 
+      [] (BaseMeshTopology & self, const sofa::Index & index) -> std::array<sofa::Index, 4> {
+          const auto & n = self.getTetrahedron(index);
+          return {{n[0], n[1], n[2], n[3]}};
+      },
+      py::arg("index"),
+      "Returns the vertices of Tetrahedron at index."
+    );
 }
 
 } // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
@@ -17,6 +17,7 @@
 *******************************************************************************
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <pybind11/stl.h>
 
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseContext.h>
@@ -35,8 +36,68 @@ using namespace sofa::core::topology;
 
 namespace sofapython3 {
 
+std::vector<int> convertEdge(const BaseMeshTopology::Edge &edge)
+{
+    static std::vector<int> vector_edge{2, 0};
+    vector_edge.at(0) = edge[0];
+    vector_edge.at(1) = edge[1];
+    return vector_edge;
+}
+
+std::vector<int> convertTetra(const BaseMeshTopology::Tetra &tetra)
+{
+    static std::vector<int> vector_tetra{4, 0};
+    vector_tetra.resize(4);
+    for (int i = 0; i < 4; i++){
+        vector_tetra.at(i) = tetra[i];
+    }    
+    return vector_tetra;
+}
+
+std::vector<int> edgesInTetrahedron(const BaseMeshTopology::EdgesInTetrahedron &edges)
+{
+    static std::vector<int> vector_edges{6, 0};
+    vector_edges.resize(6);
+    for (int i = 0; i < 6; i++){
+        vector_edges.at(i) = edges[i];
+    }
+    return vector_edges;
+}
+
 void moduleAddBaseMeshTopology(py::module& m) {
     py::class_<BaseMeshTopology, Base, py_shared_ptr<BaseMeshTopology>> c (m, "BaseMeshTopology");
+
+    /// register the ContactListener binding in the downcasting subsystem
+    PythonFactory::registerType<BaseMeshTopology>([](sofa::core::objectmodel::Base* object)
+    {
+        return py::cast(dynamic_cast<BaseMeshTopology*>(object));
+    });
+
+    c.def("getNbPoints", &BaseMeshTopology::getNbPoints);
+    c.def("getNbLines", &BaseMeshTopology::getNbLines);
+    c.def("getNbEdges", &BaseMeshTopology::getNbEdges);
+    c.def("getNbTriangles", &BaseMeshTopology::getNbTriangles);
+    c.def("getNbTetrahedra", &BaseMeshTopology::getNbTetrahedra);
+    c.def("getNbHexahedra", &BaseMeshTopology::getNbHexahedra);
+    c.def("getNbQuads", &BaseMeshTopology::getNbQuads);
+    c.def("getNbTetras", &BaseMeshTopology::getNbTetras);
+
+    c.def("getEdge", [](BaseMeshTopology &self, int i){return convertEdge(self.getEdge(i));});
+
+    c.def("getLocalEdgesInTetrahedron", [](BaseMeshTopology &self, int i){return convertEdge(self.getLocalEdgesInTetrahedron(i));},
+    R"(
+        Returns for each index (between 0 and 5) the two vertex indices that are adjacent to that edge.
+        )");
+
+    c.def("getEdgesInTetrahedron", [](BaseMeshTopology &self, int i){return edgesInTetrahedron(self.getEdgesInTetrahedron(i));},
+    R"(
+        Returns the set of edges adjacent to a given tetrahedron.
+        )");
+
+    c.def("getTetrahedron", [](BaseMeshTopology &self, int i){return convertTetra(self.getTetrahedron(i));},
+    R"(
+        Returns the vertices of Tetrahedron at index i.
+        )");
 }
 
 } // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -47,7 +47,10 @@ namespace sofapython3
     using sofa::core::behavior::MultiMatrixAccessor;
     using sofa::core::behavior::ForceField;
     using sofa::defaulttype::Vec3dTypes;
+    using sofa::defaulttype::Vec2dTypes;
+    using sofa::defaulttype::Vec1dTypes;
     using sofa::defaulttype::Rigid3dTypes;
+    using sofa::defaulttype::Rigid2dTypes;
 
     template<class TDOFType>
     ForceField_Trampoline<TDOFType>::ForceField_Trampoline() = default;
@@ -163,68 +166,44 @@ namespace sofapython3
         }
     }
 
+
+    template<class TDOFType>
+    void declare_forcefield(py::module &m, std::string typestr) {
+        std::string pyclass_name = std::string("ForceField") + typestr;
+        py::class_<ForceField<TDOFType>, BaseObject, ForceField_Trampoline<TDOFType>, py_shared_ptr<ForceField<TDOFType>>> f(m, pyclass_name.c_str(), py::dynamic_attr(), py::multiple_inheritance(), sofapython3::doc::forceField::forceFieldClass);
+        
+        f.def(py::init([](py::args &args, py::kwargs &kwargs) {
+            auto ff = sofa::core::sptr<ForceField_Trampoline<TDOFType>> (new ForceField_Trampoline<TDOFType>());
+
+            ff->f_listening.setValue(true);
+
+            if (args.size() == 1) ff->setName(py::cast<std::string>(args[0]));
+
+            py::object cc = py::cast(ff);
+            for (auto kv : kwargs) {
+                std::string key = py::cast<std::string>(kv.first);
+                py::object value = py::reinterpret_borrow<py::object>(kv.second);
+                if (key == "name") {
+                    if (args.size() != 0) {
+                        throw py::type_error("The name is set twice as a "
+                                            "named argument='" + py::cast<std::string>(value) + "' and as a"
+                                                                                                "positional argument='" +
+                                            py::cast<std::string>(args[0]) + "'.");
+                    }
+                }
+                BindingBase::SetAttr(cc, key, value);
+            }
+            return ff;
+        }));
+    }
+
+
 void moduleAddForceField(py::module &m) {
-    py::class_<ForceField<Vec3dTypes>,
-            BaseObject, ForceField_Trampoline<Vec3dTypes>,
-            py_shared_ptr<ForceField<Vec3dTypes>>> f(m, "ForceField",
-                                                     py::dynamic_attr(),
-                                                     sofapython3::doc::forceField::forceFieldClass);
-
-    f.def(py::init([](py::args &args, py::kwargs &kwargs) {
-        auto ff = sofa::core::sptr<ForceField_Trampoline<Vec3dTypes>> (new ForceField_Trampoline<Vec3dTypes>());
-
-        ff->f_listening.setValue(true);
-
-        if (args.size() == 1) ff->setName(py::cast<std::string>(args[0]));
-
-        py::object cc = py::cast(ff);
-        for (auto kv : kwargs) {
-            std::string key = py::cast<std::string>(kv.first);
-            py::object value = py::reinterpret_borrow<py::object>(kv.second);
-            if (key == "name") {
-                if (args.size() != 0) {
-                    throw py::type_error("The name is setted twice as a "
-                                         "named argument='" + py::cast<std::string>(value) + "' and as a"
-                                                                                             "positional argument='" +
-                                         py::cast<std::string>(args[0]) + "'.");
-                }
-            }
-            BindingBase::SetAttr(cc, key, value);
-        }
-        return ff;
-    }));
-
-
-    py::class_<ForceField<Rigid3dTypes>,
-            BaseObject, ForceField_Trampoline<Rigid3dTypes>,
-            py_shared_ptr<ForceField<Rigid3dTypes>>> f2(m, "ForceFieldRigid3",
-                                                        py::dynamic_attr(),
-                                                        py::multiple_inheritance(),
-                                                        sofapython3::doc::forceField::forceFieldClass);
-
-
-    f2.def(py::init([](py::args &args, py::kwargs &kwargs) {
-        auto c = sofa::core::sptr<ForceField_Trampoline<Rigid3dTypes>> (new ForceField_Trampoline<Rigid3dTypes>());
-        c->f_listening.setValue(true);
-
-        if (args.size() == 1) c->setName(py::cast<std::string>(args[0]));
-
-        py::object cc = py::cast(c);
-        for (auto kv : kwargs) {
-            std::string key = py::cast<std::string>(kv.first);
-            py::object value = py::reinterpret_borrow<py::object>(kv.second);
-            if (key == "name") {
-                if (args.size() != 0) {
-                    throw py::type_error("The name is setted twice as a "
-                                         "named argument='" + py::cast<std::string>(value) + "' and as a"
-                                                                                             "positional argument='" +
-                                         py::cast<std::string>(args[0]) + "'.");
-                }
-            }
-            BindingBase::SetAttr(cc, key, value);
-        }
-        return c;
-    }));
+    declare_forcefield<Vec3dTypes>(m, "Vec3d");
+    declare_forcefield<Vec2dTypes>(m, "Vec2d");
+    declare_forcefield<Vec1dTypes>(m, "Vec1d");
+    declare_forcefield<Rigid3dTypes>(m, "Rigid3d");
+    declare_forcefield<Rigid2dTypes>(m, "Rigid2d");
 }
 
 }  // namespace sofapython3

--- a/examples/emptyForceField.py
+++ b/examples/emptyForceField.py
@@ -5,9 +5,9 @@ import numpy as np
 
 # This python script shows the functions to be implemented
 # in order to create your ForceField in python
-class EmptyForceField(Sofa.Core.ForceField):
+class EmptyForceField(Sofa.Core.ForceFieldVec3d):
     def __init__(self, *args, **kwargs):
-        Sofa.Core.ForceField.__init__(self, *args, **kwargs)
+        Sofa.Core.ForceFieldVec3d.__init__(self, *args, **kwargs)
         pass
 
     # Function called at the component initialization

--- a/examples/example-forcefield.py
+++ b/examples/example-forcefield.py
@@ -4,10 +4,10 @@ import Sofa
 import numpy as np
 
 
-class RestShapeForceField(Sofa.Core.ForceField):
+class RestShapeForceField(Sofa.Core.ForceFieldVec3d):
     """Implementation of a RestShapeForceField in python"""
     def __init__(self, ks=1.0, kd=1.0, *args, **kwargs):
-        Sofa.Core.ForceField.__init__(self, *args, **kwargs)
+        Sofa.Core.ForceFieldVec3d.__init__(self, *args, **kwargs)
         self.addData("ks", type="float", value=ks, help="The stiffness spring", group="Spring's Properties")                  
         self.addData("kd", type="float", value=kd, help="The damping spring", group="Spring's Properties")                  
         


### PR DESCRIPTION
I needed a Vec1d type forcefield and was running into issues because the current version only supports Vec3d. So I added a function to declare each type of ForceField, ie:
```python
Sofa.Core.ForceFieldVec1d
Sofa.Core.ForceFieldVec3d
...
```