### PR TITLE
[tests] FIX all tests using MechanicalObject + Reactivate Sofa.Components

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -1,6 +1,12 @@
 project(Bindings.Sofa)
 
-set(SOFABINDINGS_MODULE_LIST Core Helper Simulation Types)
+set(SOFABINDINGS_MODULE_LIST
+    Components
+    Core
+    Helper
+    Simulation
+    Types
+    )
 
 foreach(sofabindings_module ${SOFABINDINGS_MODULE_LIST})
 	add_subdirectory(src/SofaPython3/Sofa/${sofabindings_module})

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -39,7 +39,7 @@ import Sofa.Helper
 import Sofa.Core
 import Sofa.Simulation
 import Sofa.Types
-# import Sofa.Components
+import Sofa.Components
 import SofaTypes
 
 from .prefab import *

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -49,7 +49,13 @@ sofa_auto_set_target_rpath(
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
-set(DIR_BINDING_LIST Components Core Helper Simulation Types)
+set(DIR_BINDING_LIST
+    Components
+    Core
+    Helper
+    Simulation
+    Types
+    )
 get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 foreach(dir_binding ${DIR_BINDING_LIST})
     if (_isMultiConfig) # MSVC

--- a/bindings/Sofa/tests/Core/Base.py
+++ b/bindings/Sofa/tests/Core/Base.py
@@ -3,10 +3,14 @@
 import Sofa
 import unittest
 
+def create_scene(rootName="root"):
+    root = Sofa.Core.Node(rootName)
+    root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+    return root
 
 class Test(unittest.TestCase):
     def test_data_property(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=[
                               [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         self.assertTrue(hasattr(c, "__data__"))
@@ -17,7 +21,7 @@ class Test(unittest.TestCase):
         self.assertTrue(isinstance(c.__data__, Sofa.Core.DataDict))
 
     def test_loggedMessagesBinding(self):
-        node = Sofa.Core.Node("a_node")
+        node = create_scene("a_node")
         self.assertEqual(node.getLoggedMessagesAsString(), "")
         Sofa.msg_info(node, "This is a new message")
         self.assertTrue("This is a new message" in node.getLoggedMessagesAsString())
@@ -26,7 +30,7 @@ class Test(unittest.TestCase):
         self.assertEqual(node.countLoggedMessages(), 0)
 
     def test_addNewData_with_type(self):
-        node = Sofa.Core.Node("a_node")
+        node = create_scene("a_node")
         obj = node.addObject("MechanicalObject", name="an_object", position=[
                              [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         # Check PSDEObjectFactory to see available types
@@ -42,13 +46,13 @@ class Test(unittest.TestCase):
         self.assertEqual(obj.myData.value, 42)
 
     def test_addKeywordProtected(self):
-        node = Sofa.Core.Node("a_node")
+        node = create_scene("a_node")
         self.assertRaises(ValueError, node.addObject, "MechanicalObject", name="children", position=[[0,0,0],[1,1,1],[2,2,2]])
         self.assertRaises(ValueError, node.addChild, "parents")
         self.assertRaises(ValueError, node.addData, name="links", type="int", value=42)
 
     def test_addNewDataFromParent_linkPaths(self):
-        root = Sofa.Core.Node('root')
+        root = create_scene('root')
         c1 = root.addObject("MechanicalObject", name="c1")
         c1.addData("d", value="coucou", type="string")
 
@@ -79,7 +83,7 @@ class Test(unittest.TestCase):
 
 
     def test_addNewDataFromParent(self):
-        root = Sofa.Core.Node('root')
+        root = create_scene('root')
         c1 = root.addObject("MechanicalObject", name="c1")
         c1.addData("d", value="coucou", type="string")
         c1.addData("d2", value="@c1.d")
@@ -97,7 +101,7 @@ class Test(unittest.TestCase):
 
 
     def test_addNewDataFromParent_brokenLink(self):
-        root = Sofa.Core.Node('root')
+        root = create_scene('root')
         c1 = root.addObject("MechanicalObject", name="c1")
 
         ValueError_ToTest = ["@aBroken/path.value", "@aBroken/path", "@/aBroken/path", "@", "@.", "@/", "@./", "@../"]
@@ -111,11 +115,11 @@ class Test(unittest.TestCase):
             self.assertRaises(TypeError, c1.addData, name="d", value=val)
 
     def test_getClassName(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         self.assertEqual(root.getClassName(), "DAGNode")
 
     def test_getTemplateName(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c = root.addObject("MechanicalObject", name="t")
         self.assertEqual(c.getTemplateName(),"Vec3d")
 

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -91,11 +91,15 @@ class NpArrayTestController(Sofa.Core.Controller):
         test.assertEqual(repr(self.vector_text_3entries),
                          repr(["v1", "v2", "v3"]))
 
+def create_scene(rootName="root"):
+    root = Sofa.Core.Node(rootName)
+    root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+    return root
 
 class Test(unittest.TestCase):
 
     def test_getattr(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c = root.addObject("MechanicalObject", name="c")
         self.assertEqual(str(type(c.position)), "<class 'Sofa.Core.DataContainer'>")
         c.addData("d1", type="string", value="coucou")
@@ -108,7 +112,7 @@ class Test(unittest.TestCase):
         self.assertEqual(str(type(c.bbox)), "<class 'Sofa.Types.BoundingBox'>")
 
     def test_typeName(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=[
             [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         self.assertEqual(c.position.typeName(), "vector<Vec3d>")
@@ -116,19 +120,19 @@ class Test(unittest.TestCase):
 
     # @unittest.skip  # no reason needed
     def test_ValidDataAccess(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=[
             [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         self.assertTrue(c.position is not None)
 
     # @unittest.skip  # no reason needed
     def test_InvalidDataAccess(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         self.assertRaises(AttributeError, getattr, root, "invalidData")
 
     # @unittest.skip  # no reason needed
     def test_DataAsArray2D(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2]]
         c = root.addObject("MechanicalObject", name="t", position=v)
         self.assertEqual(len(c.position.value), 3)
@@ -139,7 +143,7 @@ class Test(unittest.TestCase):
     # @unittest.skip  # no reason needed
     def test_DataArray2DSetFromList(self):
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]]
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=v)
         c.position = [[1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]
         numpy.testing.assert_array_equal(c.position.array(), [[1.0, 1.0, 1.0], [
@@ -148,7 +152,7 @@ class Test(unittest.TestCase):
     # @unittest.skip  # no reason needed
     def test_DataArray2DResizeFromArray(self):
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]]
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=v)
         zeros = numpy.zeros((100, 3), dtype=numpy.float64)
         c.position.value = zeros
@@ -157,7 +161,7 @@ class Test(unittest.TestCase):
     # @unittest.skip  # no reason needed
     def test_DataArray2DInvalidResizeFromArray(self):
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]]
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=v)
         zeros = numpy.zeros((4, 100), dtype=numpy.float64)
 
@@ -168,7 +172,7 @@ class Test(unittest.TestCase):
     # @unittest.skip  # no reason needed
     def test_DataArray2DSetFromArray(self):
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4]]
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=v)
 
         zeros = numpy.zeros((500, 3), dtype=numpy.float64)
@@ -185,7 +189,7 @@ class Test(unittest.TestCase):
 
     @unittest.skip  # no reason needed
     def test_DataArray2DElementWiseOperation(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         m = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]]
         c = root.addObject("MechanicalObject", name="t", position=v)
@@ -193,7 +197,7 @@ class Test(unittest.TestCase):
 
     def test_UnknowAttribute(self):
         """ Access a non-existing attribute of a data field so this should trigger AttributeError"""
-        root = Sofa.Core.Node("root")  # < Create a new node
+        root = create_scene("root")  # < Create a new node
         # < Create a new object
         c = root.addObject("MechanicalObject", name="t")
         p = c.position.value  # < Retrive its position
@@ -205,7 +209,7 @@ class Test(unittest.TestCase):
     # @unittest.skip  # no reason needed
 
     def test_DataArray2DOperation(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         v = numpy.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]])
         c = root.addObject("MechanicalObject", name="t", position=v.tolist())
         c2 = c.position.value * 2.0
@@ -219,7 +223,7 @@ class Test(unittest.TestCase):
 
     # @unittest.skip  # no reason needed
     def test_DataAsArray1D(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2]]
         c = root.addObject("MechanicalObject", name="t",
                            position=v, showColor=[0.42, 0.1, 0.9, 1.0])
@@ -228,7 +232,7 @@ class Test(unittest.TestCase):
 
     # @unittest.skip  # no reason needed
     def test_DataWrapper1D(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         v = [[0, 0, 0], [1, 1, 1], [2, 2, 2]]
         root.addObject("MechanicalObject", name="obj", position=v)
 
@@ -245,7 +249,7 @@ class Test(unittest.TestCase):
         self.assertRaises(ValueError, (lambda c: t(c)), color)
 
     def test_DataAsContainerNumpyArray_(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         v = numpy.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]])
         c = root.addObject("MechanicalObject", name="t", position=v.tolist())
         Sofa.Simulation.init(root)
@@ -258,7 +262,7 @@ class Test(unittest.TestCase):
             numpy.testing.assert_array_equal(c.position.array(), v)
 
     def test_DataAsContainerNumpyArrayRepeat(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         v = numpy.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]])
         c = root.addObject("MechanicalObject", name="t", position=v.tolist())
 
@@ -289,13 +293,13 @@ class Test(unittest.TestCase):
             numpy.testing.assert_array_equal(wa, v*4.0)
 
     def test_DataString(self):
-        n = Sofa.Core.Node("rootNode")
+        n = create_scene("rootNode")
         self.assertTrue(isinstance(n.name, Sofa.Core.DataString))
         self.assertEqual(n.name.value, "rootNode")
         self.assertEqual(len(n.name), 8)
 
     def test_DataAsContainerNumpyArray(self):
-        n = Sofa.Core.Node("rootNode")
+        n = create_scene("rootNode")
         c = n.addObject(NpArrayTestController(name="c"))
 
         c.testLen(self)
@@ -305,7 +309,7 @@ class Test(unittest.TestCase):
         c.testValue(self)
 
     def test_name(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
         self.assertEqual(data.getName(),"aField")
@@ -313,21 +317,21 @@ class Test(unittest.TestCase):
         self.assertEqual(data.getName(),"aNewField")
 
     def test_getValueString(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c = root.addObject("MechanicalObject", name="t", position=[[0,1,0]])
         self.assertEqual(c.position.getValueString(),"0 1 0")
 
     def test_getValueTypeString(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c = root.addObject("MechanicalObject", name="t", position=[[0,1,0]])
         self.assertEqual(c.position.getValueTypeString(),"vector<Vec3d>")
 
     def test_isRequired(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         self.assertFalse(root.name.isRequired())
 
     def test_Persistent(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
         self.assertTrue(data.isPersistent())
@@ -335,7 +339,7 @@ class Test(unittest.TestCase):
         self.assertFalse(data.isPersistent())
 
     def test_Parent(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         root.addData(name="aFieldParent", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
@@ -346,7 +350,7 @@ class Test(unittest.TestCase):
         self.assertEqual(data.getParent().getName(),"aFieldParent")
 
     def test_getLinkPath(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         root.addData(name="aFieldParent", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
@@ -356,7 +360,7 @@ class Test(unittest.TestCase):
         self.assertEqual(dataParent.getLinkPath(),"@/.aFieldParent")
 
     def test_read(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
         self.assertEqual(data.value,1.0)
@@ -365,7 +369,7 @@ class Test(unittest.TestCase):
         self.assertFalse(data.read("test"))
 
     def test_Dirty(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         root.addData(name="aFieldParent", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
@@ -378,7 +382,7 @@ class Test(unittest.TestCase):
         self.assertFalse(data.isDirty())
 
     def test_readOnly(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addData(name="aField", value=1.0 , help="help message",group="theDataGroup", type="float")
         data = root.getData("aField")
         self.assertFalse(data.isReadOnly())
@@ -386,7 +390,7 @@ class Test(unittest.TestCase):
         self.assertTrue(data.isReadOnly())
 
     def test_DownCast(self):
-        root = Sofa.Core.Node('root')
+        root = create_scene('root')
         self.assertEqual(type(root.name), Sofa.Core.DataString)
         self.assertEqual(type(root.gravity), Sofa.Core.DataContainer)
         self.assertEqual(type(root.dt), Sofa.Core.Data)

--- a/bindings/Sofa/tests/Core/BaseLink.py
+++ b/bindings/Sofa/tests/Core/BaseLink.py
@@ -4,13 +4,17 @@
 import unittest
 import Sofa
 
+def create_scene(rootName="root"):
+    root = Sofa.Core.Node(rootName)
+    root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+    return root
 
 class Test(unittest.TestCase):
     def __init__(self, a):
         unittest.TestCase.__init__(self, a)
 
     def test_Name(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addObject("MechanicalObject", name="t")
         link = root.findLink("mechanicalState")
         self.assertEqual(link.getName(),"mechanicalState")
@@ -18,7 +22,7 @@ class Test(unittest.TestCase):
         self.assertEqual(link.getName(),"newName")
 
     def test_Help(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addObject("MechanicalObject", name="t")
         link = root.findLink("mechanicalState")
         self.assertEqual(link.getHelp(), 'The MechanicalState attached to this node (storing all state vectors)')
@@ -26,7 +30,7 @@ class Test(unittest.TestCase):
         self.assertEqual(link.getHelp(), 'new help')
 
     def test_isMultiLink(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addObject("MechanicalObject", name="t")
         link = root.findLink("mechanicalState")
         self.assertFalse(link.isMultiLink())
@@ -35,7 +39,7 @@ class Test(unittest.TestCase):
         self.assertTrue(link.isMultiLink())
 
     def test_Persistent(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addObject("MechanicalObject", name="t")
         link = root.findLink("mechanicalState")
         self.assertFalse(link.isPersistent())
@@ -45,7 +49,7 @@ class Test(unittest.TestCase):
         self.assertFalse(link.isReadOnly())
 
     def test_getSize(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         link = root.findLink("child")
         self.assertEqual(link.getSize(),0)
         root.addChild("child1")
@@ -56,31 +60,31 @@ class Test(unittest.TestCase):
         self.assertEqual(link.getSize(),2)
 
     def test_getValue(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addChild("child1")
         link = root.findLink("child")
         self.assertEqual(link.getValueString(), "@/child1")
         self.assertEqual(link.getValueTypeString(), "Node")
 
     def test_getLinkedPath(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c1 = root.addChild("child1")
         link = root.findLink("child")
         self.assertEqual(link.getLinkedPath(0), "@/child1")
 
     def test_getOwnerBase(self):
-        root = Sofa.Core.Node("theRoot")
+        root = create_scene("theRoot")
         link = root.findLink("child")
         self.assertEqual(link.getOwnerBase().name.value,"theRoot")
 
     def test_getLinkedBase(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         root.addChild("aChild")
         link = root.findLink("child")
         self.assertEqual(link.getLinkedBase(0).name.value,"aChild")
 
     def test_getLinked_and_Owner(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c1 = root.addObject("MechanicalObject", name="t1")
         c2 = root.addObject("MechanicalObject", name="t2")
         mm  = root.addObject("BarycentricMapping", input="@/t1", output="@/t2")
@@ -93,7 +97,7 @@ class Test(unittest.TestCase):
 
     @unittest.skip # Segmentation fault on MacOS
     def test_read(self):
-        root = Sofa.Core.Node("root")
+        root = create_scene("root")
         c1 = root.addObject("MechanicalObject", name="t1")
         link = root.findLink("object")
         self.assertEqual(link.getValueString(),"@//t1", F"Link value should be '@//t1', but it is {link.getValueString()}")

--- a/bindings/Sofa/tests/Core/BaseObject.py
+++ b/bindings/Sofa/tests/Core/BaseObject.py
@@ -3,25 +3,29 @@
 import unittest
 import Sofa
 
+def create_scene(rootName="root"):
+    root = Sofa.Core.Node(rootName)
+    root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+    return root
 
 class Test(unittest.TestCase):
     def __init__(self, a):
         unittest.TestCase.__init__(self, a)
 
     def test_createObjectWithParam(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=[
                            [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         self.assertTrue(c is not None)
 
     def test_createObjectWithInvalidParamName(self):
         # This one should raise an error because of 'v' should rise a type error.
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         self.assertRaises(TypeError, root.addObject, "MechanicalObject", name="tt", v=[
                           [0, 0, 0], [1, 1, 1], [2, 2, 2]])
 
     def test_data_property(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=[
                            [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         self.assertTrue(hasattr(c, "__data__"))
@@ -32,13 +36,13 @@ class Test(unittest.TestCase):
         self.assertTrue(isinstance(c.__data__, Sofa.Core.DataDict))
 
     def test_context(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t", position=[
                            [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         self.assertTrue(c.getContext() is not None)
 
     def test_slave_master(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c_master = root.addObject("MechanicalObject", name="t_master", position=[
                                   [0, 0, 0], [1, 1, 1], [2, 2, 2]])
         c_slave = root.addObject("MechanicalObject", name="t_slave", position=[
@@ -49,33 +53,33 @@ class Test(unittest.TestCase):
         self.assertEqual(c_slave.getSlaves(), [])
 
     def test_getTarget(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t")
         self.assertEqual(c.getTarget(), 'SofaBaseMechanics')
 
     def test_getName(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t")
         self.assertEqual(c.getName(), "t")
 
     def test_getCategories(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t")
         self.assertEqual(c.getCategories(), ["MechanicalState"])
 
     def test_getPathName(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t")
         self.assertEqual(c.getPathName(), "/t")
 
     def test_getLinkPath(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("MechanicalObject", name="t")
         self.assertEqual(c.getLinkPath(), "@/t")
         self.assertEqual(c.getAsACreateObjectParameter(), "@/t")
 
     def test_setSrc(self):
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("Binding_BaseObject_MockComponent", name="t")
         loader = root.addObject(
             "Binding_BaseObject_MockComponent", name="loader")
@@ -87,7 +91,7 @@ class Test(unittest.TestCase):
         # Test several binded functions using the Binding_BaseObject_MockComponent
         t = ["bwdInit", "cleanup", "computeBBox",
              "storeResetState", "reset", "init", "reinit"]
-        root = Sofa.Core.Node("rootNode")
+        root = create_scene("rootNode")
         c = root.addObject("Binding_BaseObject_MockComponent", name="t")
         for name in t:
             getattr(c, name)()

--- a/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
+++ b/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
@@ -53,11 +53,11 @@ static struct PythonModule_Sofa_tests : public PythonTestExtractor
     PythonModule_Sofa_tests()
     {
         const std::string executable_directory = sofa::helper::Utils::getExecutableDirectory();
-        addTestDirectory(executable_directory+"/Components", "Sofa_Components_");
         addTestDirectory(executable_directory+"/Core", "Sofa_Core_");
         addTestDirectory(executable_directory+"/Helper", "Sofa_Helper_");
         addTestDirectory(executable_directory+"/Simulation", "Sofa_Simulation_");
         addTestDirectory(executable_directory+"/Types", "Sofa_Types_");
+        addTestDirectory(executable_directory+"/Components", "Sofa_Components_");
     }
 } python_tests;
 

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -33,6 +33,7 @@ class Test(unittest.TestCase):
 
         def test_GetAttr(self):
                 root = Sofa.Core.Node("rootNode")
+                root.addObject("RequiredPlugin", name="SofaBaseMechanics")
                 c = root.addChild("child1")
                 self.assertTrue(c is not None)
                 self.assertTrue(root.child1 is not None)
@@ -43,6 +44,7 @@ class Test(unittest.TestCase):
 
         def test_init(self):
                 root = Sofa.Core.Node("rootNode")
+                root.addObject("RequiredPlugin", name="SofaBaseMechanics")
                 c = root.addChild("child1")
                 c = c.addObject("MechanicalObject", name="MO", position=[0.0,1.0,2.0]*100)
                 root.init()
@@ -84,6 +86,7 @@ class Test(unittest.TestCase):
 
         def test_createObjectWithParam(self):
                 root = Sofa.Core.Node("rootNode")
+                root.addObject("RequiredPlugin", name="SofaBaseMechanics")
                 root.addObject("MechanicalObject", name="mechanical", position=[[0,0,0],[1,1,1],[2,2,2]])
                         
         def test_children_property(self):                
@@ -113,11 +116,13 @@ class Test(unittest.TestCase):
 
         def test_objects_property(self):
                 root = Sofa.Core.Node("rootNode")
-                root.addObject("MechanicalObject", name="name1")
-                root.addObject("MechanicalObject", name="name2")
-                self.assertEqual(len(root.objects), 2)
-                root.addObject("MechanicalObject", name="name2")
-                self.assertEqual(len(root.objects), 3)
+                root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+                child = root.addChild(Sofa.Core.Node("child1"))
+                child.addObject("MechanicalObject", name="name1")
+                child.addObject("MechanicalObject", name="name2")
+                self.assertEqual(len(child.objects), 2)
+                child.addObject("MechanicalObject", name="name2")
+                self.assertEqual(len(child.objects), 3)
 
         def test_data_property(self):
                 root = Sofa.Core.Node("rootNode")
@@ -129,6 +134,7 @@ class Test(unittest.TestCase):
 
         def test_getItem(self):
             root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
             node1 = root.addChild('node1')
             object1 = root.addObject("MechanicalObject", name="object1")
             node2 = node1.addChild('node2')
@@ -170,18 +176,21 @@ class Test(unittest.TestCase):
 
         def test_removeObject(self):
             root = Sofa.Core.Node("root")
-            obj1 = root.addObject("MechanicalObject", name="obj1")
-            obj2 = root.addObject("MechanicalObject", name="obj2")
-            self.assertEqual(len(root.objects), 2)
-            self.assertTrue(hasattr(root,"obj1"))
-            self.assertTrue(hasattr(root,"obj2"))
-            root.removeObject(obj1)
-            self.assertEqual(len(root.objects), 1)
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+            child = root.addChild(Sofa.Core.Node("child1"))
 
-            self.assertFalse(hasattr(root,"obj1"))
-            root.removeObject(obj2)
-            self.assertFalse(hasattr(root,"obj2"))
-            self.assertEqual(len(root.objects), 0)
+            obj1 = child.addObject("MechanicalObject", name="obj1")
+            obj2 = child.addObject("MechanicalObject", name="obj2")
+            self.assertEqual(len(child.objects), 2)
+            self.assertTrue(hasattr(child,"obj1"))
+            self.assertTrue(hasattr(child,"obj2"))
+            child.removeObject(obj1)
+            self.assertEqual(len(child.objects), 1)
+
+            self.assertFalse(hasattr(child,"obj1"))
+            child.removeObject(obj2)
+            self.assertFalse(hasattr(child,"obj2"))
+            self.assertEqual(len(child.objects), 0)
 
         def test_moveChild(self):
             root1 = Sofa.Core.Node("root1")
@@ -217,24 +226,28 @@ class Test(unittest.TestCase):
 
         def test_getMass(self):
             root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
             root.addObject("MechanicalObject")
             m = root.addObject("UniformMass", name="mass", vertexMass=0.1)
             self.assertEqual(m,root.getMass())
 
         def test_getForceField(self):
-            SofaRuntime.importPlugin('SofaBoundaryCondition')
             root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBoundaryCondition")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
             root.addObject("MechanicalObject")
             ff = root.addObject('ConstantForceField', template="Vec3d", name="cff2")
             self.assertEqual(ff, root.getForceField(0))
 
         def test_getMechanicalState(self):
             root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
             c = root.addObject("MechanicalObject")
             self.assertEqual(c, root.getMechanicalState())
 
         def test_getMechanicalMapping(self):
             root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
             root.addObject("MechanicalObject", name="t1")
             root.addObject("MechanicalObject", name="t2")
             mm  = root.addObject("BarycentricMapping", input="@/t1", output="@/t2")

--- a/bindings/Sofa/tests/Types/Vec3.py
+++ b/bindings/Sofa/tests/Types/Vec3.py
@@ -3,6 +3,11 @@ import unittest
 import Sofa
 from Sofa.PyTypes import Vec3
 
+def create_scene(rootName="root"):
+    root = Sofa.Core.Node(rootName)
+    root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+    return root
+
 class Test(unittest.TestCase):
     def test_constructor(self):
         v0 = Vec3()
@@ -12,12 +17,12 @@ class Test(unittest.TestCase):
         self.assertEqual( v2, v1 )
 
     def test_wrapAroundArray(self):
-        n = Sofa.Core.Node("node")
+        n = create_scene()
         m = n.addObject("MechanicalObject", position=[[1.0,1.1,1.2],[2.0,2.1,2.2],[3.0,3.1,3.2]])
         self.assertRaises(AttributeError, Vec3, m.position.array())
 
     def test_wrapInvalidSize(self):
-        n = Sofa.Core.Node("node")
+        n = create_scene()
         m = n.addObject("MechanicalObject")
         def d():
             return Vec3(m.showColor)
@@ -25,7 +30,7 @@ class Test(unittest.TestCase):
 
 
     def test_wrapAroundSingleField(self):
-        n = Sofa.Core.Node("node")
+        n = create_scene()
         m = n.addObject("MechanicalObject", translation=[1.0,0.0,0.0])
         c = Vec3(m.translation)
         self.assertEqual(c.tolist(), [1.0,0.0,0.0])

--- a/bindings/Sofa/tests/bench_datacontainer.py
+++ b/bindings/Sofa/tests/bench_datacontainer.py
@@ -9,6 +9,7 @@ import SofaRuntime
 rawcpy = numpy.zeros((1000000,3), dtype=numpy.float64)
 
 root = Sofa.Core.Node("root")
+root.addObject("RequiredPlugin", name="SofaBaseMechanics")
 obj = root.createObject("MechanicalObject", name="test", position=rawcpy.tolist())
 
 it=10

--- a/bindings/Sofa/tests/benchmark.py
+++ b/bindings/Sofa/tests/benchmark.py
@@ -15,6 +15,7 @@ slowcpy = numpy.zeros((1000000,3), dtype=numpy.float32)
 aList = rawcpy.tolist()
 
 root = Sofa.Core.Node("root")
+root.addObject("RequiredPlugin", name="SofaBaseMechanics")
 obj = root.createObject("MechanicalObject", name="test", position=aList)
 
 obj.position = aList

--- a/bindings/Sofa/tests/dataaccess.py
+++ b/bindings/Sofa/tests/dataaccess.py
@@ -20,6 +20,7 @@ ones = numpy.ones((1000,3), dtype=numpy.float64)
 aList = zeros.tolist()
 
 root = Sofa.Core.Node("root")
+root.addObject("RequiredPlugin", name="SofaBaseMechanics")
 obj = root.createObject("MechanicalObject", name="test", position=aList)
 print("A counter: ", obj.position.getCounter())
 obj.position += ones


### PR DESCRIPTION
When Sofa.Components was activated, its test (bindings/Sofa/tests/Components/Components.py) was the first test executed. 
This test contains a `root.addObject('RequiredPlugin', name='SofaBaseMechanics')`. 
Well, **there is no Python environment cleaning between each test**. 
Thus SP3 tests benefit from the RequiredPlugin done by all the tests executed before.
That is why the deactivation of Sofa.Components made all those tests fail with "cannot create MechanicalObject".

What I did:
- re-enable Sofa.Components (and its test) and move the test to be the last executed
- fix all SP3 tests that use MechanicalObject with some "RequiredPlugin SofaBaseMechanics"
