### PR TITLE
Fix __setattr__

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -126,16 +126,8 @@ void BindingBase::SetAttr(py::object self, const std::string& s, py::object valu
         return;
     }
 
-    /// We are falling back to dynamically adding the objet into the object dict.
-    py::dict t = self.attr("__dict__");
-    if(!t.is_none())
-    {
-        t[s.c_str()] = value;
-        return;
-    }
-
-    /// Well this should never happen unless there is no __dict__
-    throw py::attribute_error("Unable to set attribute '"+s+"', unknow data type");
+    // If it's not a data or a link, rely on object implementation of __setattr__
+    py::module::import("builtins").attr("object").attr("__setattr__")(self, s, value);
 }
 
 void BindingBase::SetAttr(Base& self, const std::string& s, py::object value)


### PR DESCRIPTION
If attribute is not a data or a link, calls the default implementation for __setattr__. This allows to have properties for custom types defined by a user. 