### PR TITLE
[SofaPython3] Add an hasObject method in Binding_Node to detect if a node has an object.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -159,6 +159,14 @@ void removeObject(Node& self, BaseObject* object)
     self.removeObject(object);
 }
 
+py::object hasObject(Node &n, const std::string &name)
+{
+    BaseObject *object = n.getObject(name);
+    if (object)
+        return py::cast(true);
+    return py::cast(false);
+}
+
 /// Implement the addObject function.
 py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs& kwargs)
 {
@@ -477,6 +485,7 @@ void moduleAddNode(py::module &m) {
     p.def("addObject", &addObjectKwargs, sofapython3::doc::sofa::core::Node::addObjectKwargs);
     p.def("addObject", &addObject, sofapython3::doc::sofa::core::Node::addObject, py::keep_alive<0, 2>());
     p.def("createObject", &createObject, sofapython3::doc::sofa::core::Node::createObject);
+    p.def("hasObject", &hasObject, sofapython3::doc::sofa::core::Node::hasObject);
     p.def("addChild", &addChildKwargs, sofapython3::doc::sofa::core::Node::addChildKwargs);
     p.def("addChild", &addChild, sofapython3::doc::sofa::core::Node::addChild);
     p.def("createChild", &createChild, sofapython3::doc::sofa::core::Node::createChild);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -146,10 +146,20 @@ static auto addObject =
         :type object: Sofa.Simulation.BaseObject*
         )";
 
-
 static auto createObject =
         R"(
         Deprecated, see addObject
+        )";
+
+static auto hasObject =
+        R"(
+        Check if there is a component with provided name.
+
+        :param n
+        :param name
+        :type n: Sofa.Simulation.Node
+        :type name: string
+        :return: True if the node has an object with correspdonding name.
         )";
 
 static auto addChildKwargs =
@@ -188,7 +198,7 @@ static auto getChild =
         :param name
         :type n: Sofa.Simulation.Node
         :type name: string
-        :return: the child of the same name
+        :return: the child with 'name', None otherwise
         )";
 
 static auto removeChild =

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -174,6 +174,19 @@ class Test(unittest.TestCase):
             self.assertEqual(node.getLinkPath(),"@/node")
             self.assertEqual(node2.getLinkPath(), "@/node/node2")
 
+        def test_hasObjectWithFastPath(self):
+            root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+            self.assertTrue(root.hasObject("SofaBaseMechanics"))
+            self.assertFalse(root.hasObject("NonExistingObjectName"))
+
+        def test_hasObjectWithDefaultPythonFunction(self):
+            root = Sofa.Core.Node("root")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+
+            self.assertTrue(hasattr(root, "SofaBaseMechanics"))
+            self.assertFalse(hasattr(root, "NonExistingObjectName"))
+
         def test_removeObject(self):
             root = Sofa.Core.Node("root")
             root.addObject("RequiredPlugin", name="SofaBaseMechanics")


### PR DESCRIPTION
With the current binding it is possible to detect if a node has an object using
the default python hasattr() function. But because of how hasattr() is implement
it imply the generation of the bindinged object regardeless this is usefull or not
from the callee's point of view.

So we add a fast path version, with the corresponding documentation and tests.