### PR TITLE
Remove inclusion of a header from Sofa.Compat (again)

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseCamera.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseCamera.cpp
@@ -18,7 +18,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include "sofa/defaulttype/Quat.h"
+#include <sofa/type/Quat.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>


### PR DESCRIPTION
Forgotten from #149