### PR TITLE
[MSVC] Fix link error in debug configuration

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -30,7 +30,18 @@
 #pragma push_macro("slots")
 #undef slots
 /// This should come from python3.
+#if defined(_DEBUG) && defined(WIN32)
+#define DONT_FORGET_TO_ENABLE_DEBUG
+#endif // defined(_DEBUG) && defined(WIN32)
+
+#undef _DEBUG //Prevent linking debug build of python
 #include <Python.h>
+
+#ifdef DONT_FORGET_TO_ENABLE_DEBUG
+#define _DEBUG 1
+#undef  DONT_FORGET_TO_ENABLE_DEBUG
+#endif
+
 #pragma pop_macro("slots")
 
 #include <sofa/simulation/SceneLoaderFactory.h>

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -30,18 +30,13 @@
 #pragma push_macro("slots")
 #undef slots
 /// This should come from python3.
-#if defined(_DEBUG) && defined(WIN32)
-#define DONT_FORGET_TO_ENABLE_DEBUG
-#endif // defined(_DEBUG) && defined(WIN32)
-
-#undef _DEBUG //Prevent linking debug build of python
-#include <Python.h>
-
-#ifdef DONT_FORGET_TO_ENABLE_DEBUG
-#define _DEBUG 1
-#undef  DONT_FORGET_TO_ENABLE_DEBUG
+#if defined(WIN32) && defined(_DEBUG)
+    #undef _DEBUG // Prevent linking debug build of python
+    #include <Python.h>
+    #define _DEBUG 1
+#else
+    #include <Python.h>
 #endif
-
 #pragma pop_macro("slots")
 
 #include <sofa/simulation/SceneLoaderFactory.h>


### PR DESCRIPTION
"Hack" to force to link with the release version of python3x.lib
The link command is contained deep in python (pyconfig.h):
```
/* For an MSVC DLL, we can nominate the .lib files used by extensions */
#ifdef MS_COREDLL
#       if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
                /* not building the core - must be an ext */
#               if defined(_MSC_VER)
                        /* So MSVC users need not specify the .lib
                        file in their Makefile (other compilers are
                        generally taken care of by distutils.) */
#                       if defined(_DEBUG)
#                               pragma comment(lib,"python39_d.lib")
#                       elif defined(Py_LIMITED_API)
#                               pragma comment(lib,"python3.lib")
#                       else
#                               pragma comment(lib,"python39.lib")
#                       endif /* _DEBUG */
#               endif /* _MSC_VER */
#       endif /* Py_BUILD_CORE */
#endif /* MS_COREDLL */
```

So according to various sources, the "best" way is to disable debug before including python.h
https://bugs.python.org/issue22411