### PR TITLE
[Binding/Sofa.Core] FIX  Node iterators.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_NodeIterator.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_NodeIterator.cpp
@@ -43,7 +43,7 @@ void moduleAddNodeIterator(py::module &m)
 
     d.def("__getitem__", [](NodeIterator& d, const std::string& name) -> py::object
     {
-        BaseObject* obj =d.owner->getObject(name);
+        sofa::core::objectmodel::Base* obj = d.get_by_name(d.owner.get(), name);
         if(obj==nullptr)
             throw py::index_error("No existing object '"+name+"'");
         return PythonFactory::toPython(obj);
@@ -71,15 +71,11 @@ void moduleAddNodeIterator(py::module &m)
     });
     d.def("remove_at", [](NodeIterator& d, size_t index)
     {
-        sofa::core::sptr<sofa::core::objectmodel::BaseNode> n(
-                dynamic_cast<sofa::core::objectmodel::BaseNode *>(d.get(d.owner.get(), index).get())
-        );
-        d.owner->removeChild(n);
+        return d.remove_at(d.owner.get(), index);
     });
-    d.def("__contains__", [](NodeIterator& d, const std::string& name) -> py::object
+    d.def("__contains__", [](NodeIterator& d, const std::string& name)
     {
-        BaseObject* obj =d.owner->getObject(name);
-        return py::cast(obj==nullptr);
+        return d.get_by_name(d.owner.get(), name) != nullptr;
     });
 }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_NodeIterator.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_NodeIterator.cpp
@@ -76,6 +76,11 @@ void moduleAddNodeIterator(py::module &m)
         );
         d.owner->removeChild(n);
     });
+    d.def("__contains__", [](NodeIterator& d, const std::string& name) -> py::object
+    {
+        BaseObject* obj =d.owner->getObject(name);
+        return py::cast(obj==nullptr);
+    });
 }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_NodeIterator.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_NodeIterator.h
@@ -26,19 +26,42 @@
 
 namespace sofapython3 {
 
-class NodeIterator {
+/// Generic implementation to iterator over the different structures of a Node.
+/// This allows to implement pythonic solution as in:
+///     for object in node.objects:
+///          print(object.name)
+///
+/// or
+///     for child in node.children:
+///          print(child.name)
+///
+/// there is also support for several function like:
+///     len(node.children)
+///     if "MyName" in node.children
+///     node.children.remove_at(index)
+///
+/// The implementation is generic by the use of lamda function allowing to specify which
+/// data structure is actually iterated.
+class NodeIterator
+{
 public:
     sofa::core::sptr<sofa::simulation::Node> owner;
     size_t     index=0;
     std::function<size_t (sofa::simulation::Node *)> size ;
     std::function<sofa::core::sptr<sofa::core::Base> (sofa::simulation::Node *, size_t)> get ;
+    std::function<sofa::core::Base* (const sofa::simulation::Node *, const std::string&)> get_by_name ;
+    std::function<void (sofa::simulation::Node*, unsigned int)> remove_at;
 
     NodeIterator(sofa::core::sptr<sofa::simulation::Node> owner_,
                  std::function<size_t (sofa::simulation::Node *)> size_,
-                 std::function<sofa::core::sptr<sofa::core::Base> (sofa::simulation::Node *, size_t)> get_)
+                 std::function<sofa::core::sptr<sofa::core::Base> (sofa::simulation::Node *, size_t)> get_,
+                 std::function<sofa::core::Base* (const sofa::simulation::Node *, const std::string&)> get_by_name_,
+                 std::function<void (sofa::simulation::Node*, unsigned int)> remove_at_)
     {
         size = size_;
         get = get_;
+        get_by_name = get_by_name_;
+        remove_at = remove_at_;
         owner=owner_;
         index=0;
     }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -245,29 +245,52 @@ static auto getLinkPath =
 static auto children =
         R"(
         Field interface to acces the children of a node.
+        The returned object is a iteratable featuring the following operations:
+        len, remove_at, __contains__, get_at
 
         :Example:
         >>> n = Sofa.Core.Node("MyNode")
+        >>> n.addChild("child1")
         >>> for child in n.children:
         >>>     print(child.name)
+        >>>
+        >>> if "child1" in n.children:
+        >>>     print("Yes")
+        >>> print(len(n.children))
         )";
 
 static auto parents =
         R"(
         Field interface to acces the parents of a node.
+        The returned object is a iteratable featuring the following operations:
+        len, remove_at, __contains__, get_at
+
         :Example:
-        >>> n = Sofa.Core.Node("MyNode")
-        >>> for parent in n.parents:
+        >>> n = Sofa.Core.Node("parent1")
+        >>> c = n.addChild("child1")
+        >>> for parent in c.parents:
         >>>     print(parent.name)
+        >>>
+        >>> if "parent1" in c.parents:
+        >>>     print("Yes")
+        >>> print(len(n.parents))
         )";
 static auto objects =
         R"(
         Field interface to acces the objects of a node.
+        The returned object is a iteratable featuring the following operations:
+        len, remove_at, __contains__, get_at
 
         :Example:
         >>> n = Sofa.Core.Node("MyNode")
+        >>> n.addObject("MechanicalObject", name="object1")
+        >>> n.addObject("MechanicalObject", name="object2")
         >>> for object in n.objects:
         >>>     print(object.name)
+        >>>
+        >>> if "object2" in c.objects:
+        >>>     print("Yes")
+        >>> print(len(n.objects))
         )";
 static auto removeObject =
         R"(

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -124,6 +124,30 @@ class Test(unittest.TestCase):
                 child.addObject("MechanicalObject", name="name2")
                 self.assertEqual(len(child.objects), 3)
 
+        def test_objects_property_contains_method(self):
+            root = Sofa.Core.Node("rootNode")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+            child = root.addChild(Sofa.Core.Node("child1"))
+            child.addObject("MechanicalObject", name="name1")
+            child.addObject("MechanicalObject", name="name2")
+            self.assertTrue("child1" in root.children)
+            self.assertFalse("child2" in root.children)
+            self.assertTrue("name1" in child.objects)
+            self.assertTrue("name2" in child.objects)
+            self.assertFalse("name3" in child.objects)
+
+        def test_objects_property_remove_at_method(self):
+            root = Sofa.Core.Node("rootNode")
+            root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+            child = root.addChild(Sofa.Core.Node("child1"))
+            child.addObject("MechanicalObject", name="name1")
+            child.addObject("MechanicalObject", name="name2")
+            self.assertTrue("name1" in child.objects)
+            self.assertTrue("name2" in child.objects)
+            child.objects.remove_at(1)
+            self.assertTrue("name1" in child.objects)
+            self.assertFalse("name2" in child.objects)
+
         def test_data_property(self):
                 root = Sofa.Core.Node("rootNode")
                 self.assertTrue(hasattr(root, "__data__"))


### PR DESCRIPTION
The actually implmentation of NodeIterator is broken.
Eg:
   - the ```__getitem__``` by name was always returning a BaseObject whatever the iterable was on object, children or parents
   - the remove_at method was actually always deleting a Child whatever the iterable was on object, children or parents
There is also no ```__contains__ ```operator which prevent to write pythonic
```python
if "AAA" in node.objects:
   pass.
```

This PR:
- fix the broken implementation on remove_at and ```__getitem__``` by adding lambda functions allowing to implement per-type behavior.
- add tests for the fixed features
- implements the ```__contains__``` method and dedicated tests.
- update the corresponding docstring

DRAFTED CODE FROM THE CODE-REVIEW:
```python

def createScene(root):
    # Python2 
    root.getObjects() # 
    root.getObject("Nom")
    
    # Python3 
    __iterator__
    for i in root.getObjects(): => list(root.getObjects())
        
    for object in root.objects:
            print(object.getName())

    
    if root.getObject("Toto") != None:
    
    if "Toto" in root.getObjects():



    for object in root.objects:
        print(object.getName())                # Lazy
    
    if "Toto" in root.objects:                 # Test d'inclusion en temps constant
        # => root.getObjec("Toto")    
        
    del "Toto" in root.objects:                # Remove    
    
    root.objects
    root.parents

    root.children
    
```