### PR TITLE
[SofaPython3] Call init() by default when creating a python object.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -18,7 +18,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-
 /// Neede to have automatic conversion from pybind types to stl container.
 #include <pybind11/stl.h>
 
@@ -170,11 +169,17 @@ py::object hasObject(Node &n, const std::string &name)
 /// Implement the addObject function.
 py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs& kwargs)
 {
+    bool doInit = true;
     if (kwargs.contains("name"))
     {
         std::string name = py::str(kwargs["name"]);
         if (sofapython3::isProtectedKeyword(name))
             throw py::value_error("addObject: Cannot call addObject with name " + name + ": Protected keyword");
+    }
+    if (kwargs.contains("__noInit"))
+    {
+        doInit = !py::bool_(kwargs["__noInit"]);
+        kwargs.attr("pop")("__noInit");
     }
     /// Prepare the description to hold the different python attributes as data field's
     /// arguments then create the object.
@@ -209,6 +214,10 @@ py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs
         BaseData* d = object->findData(py::cast<std::string>(a.first));
         if(d)
             d->setPersistent(true);
+    }
+    if(doInit)
+    {
+        object->init();
     }
     return PythonFactory::toPython(object.get());
 }

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -42,14 +42,21 @@ class Test(unittest.TestCase):
                 self.assertTrue(o is not None)
                 self.assertTrue(root.child1.mechanical is not None)
 
-        def test_init(self):
+        def test_addObject_noInit(self):
+                root = Sofa.Core.Node("rootNode")
+                root.addObject("RequiredPlugin", name="SofaBaseMechanics")
+                c = root.addChild("child1")
+                c = c.addObject("MechanicalObject", name="MO", position=[0.0,1.0,2.0]*100, __noInit=True)
+                self.assertEqual(len(c.rest_position.value), 0)
+                c.init()
+                self.assertEqual(len(c.rest_position.value), 100)
+
+        def test_addObject_defaultInit(self):
                 root = Sofa.Core.Node("rootNode")
                 root.addObject("RequiredPlugin", name="SofaBaseMechanics")
                 c = root.addChild("child1")
                 c = c.addObject("MechanicalObject", name="MO", position=[0.0,1.0,2.0]*100)
-                root.init()
-                print("TYPE: "+str(len(c.position.value)))
-                self.assertEqual(len(c.position.value), 100)
+                self.assertEqual(len(c.rest_position.value), 100)
 
         def test_createObjectInvalid(self):
                 root = Sofa.Core.Node("rootNode")


### PR DESCRIPTION
The default behavior should be the most common use case while more
rare scenario should be accessible through explicit call.

Currently the default case is:
   m = r.addObject("MechanicalObject", position=[1,2,3])
   m.init()
   l.rest_position() ## Rest position is created from position at init

This is a bit weird as one may expect that once "created" in python the object is
immediately accessible in an inited state (not doing so imply user to call init() at every lines).

After the PR the default case become:
   m = r.addObject("MechanicalObject", position=[1,2,3])
   l.rest_position()

But for rare use case where it makes sense the no init behavior can be done like that:
   m = r.addObject("MechanicalObject", position=[1,2,3], doNoInit=True)
   l.rest_position() # Rest position is "uninited"
   m.init()          # You can control when you init the object
   l.rest_position() #

Unit tests are provided to validate the behavior.