### PR TITLE
[Binding] Improves of the setting of data field of type string.

### DIFF
--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -291,9 +291,10 @@ void copyFromListOf<std::string>(BaseData& d, const AbstractTypeInfo& nfo, const
 
 void PythonFactory::fromPython(BaseData* d, const py::object& o)
 {
-
     const AbstractTypeInfo& nfo{ *(d->getValueTypeInfo()) };
 
+    // Is this data field a container ?
+    // If no we fill it with direct access.
     if(!nfo.Container())
     {
         scoped_writeonly_access guard(d);
@@ -326,6 +327,18 @@ void PythonFactory::fromPython(BaseData* d, const py::object& o)
         }
 
         return ;
+    }
+
+    // The data field is a container, and we want to sets its value from a python string.
+    // This is the old sofa-behavior that we want to avoid.
+    // To smooth the deprecation process we are still allowing it ...but prints a warning.
+    if( !nfo.Text() && py::isinstance<py::str>(o) )
+    {
+        msg_deprecated(d->getOwner()) << "Data field '" << d->getName() << "' is initialized from a string."
+                                      << " This behavior was allowed with SofaPython2 but have very poor performance so it is now "
+                                      << "deprecated with SofaPython3. Please fix your scene (as this behavior will be removed).";
+        d->read( py::cast<std::string>(o) );
+        return;
     }
 
     if(nfo.Integer())

--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -301,7 +301,17 @@ void PythonFactory::fromPython(BaseData* d, const py::object& o)
         if(nfo.Integer()) {
             nfo.setIntegerValue(guard.ptr, 0, py::cast<int>(o));
         } else if(nfo.Text()) {
-            nfo.setTextValue(guard.ptr, 0, py::cast<py::str>(o));
+            if(py::isinstance<py::str>(o))
+            {
+                nfo.setTextValue(guard.ptr, 0, py::cast<py::str>(o));
+            }
+            else
+            {
+                std::stringstream s;
+                s<< "trying to set value for '"
+                 << d->getName() << "' from a python object of type " << py::cast<std::string>(py::str(o.get_type()))  ;
+                throw std::runtime_error(s.str());
+            }
         } else if(nfo.Scalar()) {
             nfo.setScalarValue(guard.ptr, 0, py::cast<double>(o));
         } else {
@@ -354,7 +364,7 @@ void PythonFactory::fromPython(BaseData* d, const py::object& o)
 
     std::stringstream s;
     s<< "binding problem, trying to set value for "
-     << d->getName() << ", " << py::cast<std::string>(py::str(o));
+     << d->getName() << ", from " << py::cast<std::string>(py::str(o.get_type()));
     throw std::runtime_error(s.str());
 }
 

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -292,6 +292,13 @@ class Test(unittest.TestCase):
             self.assertEqual(wa[2, 2], 8.0)
             numpy.testing.assert_array_equal(wa, v*4.0)
 
+    def test_set_value_from_string(self):
+        n = create_scene("rootNode")
+        n.gravity.value = [1.0,2.0,3.0]
+        self.assertEqual(list(n.gravity.value), [1.0,2.0,3.0])
+        n.gravity.value = "4.0 5.0 6.0"
+        self.assertEqual(list(n.gravity.value), [4.0,5.0,6.0])
+
     def test_DataString(self):
         n = create_scene("rootNode")
         self.assertTrue(isinstance(n.name, Sofa.Core.DataString))


### PR DESCRIPTION
1) It is not possible to set data's value from string as it was possible in SofaPython2
This PR restore the SofaPython2 behavior to ease the transition process.
But, when using it, a deprecation message is now emitted. 
A test is provided to validate the behavior.

2) Improve the exception returned when trying to set value from an invalid type.
```python
object.name.value = ["Name"]
print(object.name.value)      # is printing '["Name"]'
```
This behavior is not correct and is the consequence of how we set the value for data of type 'string' value. 
In the PR we don't allow this anymore by rising an exception.
```python
object.name.value = ["Name"]
# Rise the following exception:
[ERROR]   [SofaPython3::SceneLoader] RuntimeError: trying to set value for 'name' from a python object of type <class 'list'>
```