### PR TITLE
Remove usage of boost::filesystem

### DIFF
--- a/Plugin/src/SofaPython3/PythonTest.h
+++ b/Plugin/src/SofaPython3/PythonTest.h
@@ -24,8 +24,8 @@
 #include <SofaPython3/config.h>
 #include <sofa/helper/testing/BaseTest.h>
 
-#include <boost/filesystem/path.hpp>
-using boost::filesystem::path;
+#include <filesystem>
+using std::filesystem::path;
 
 namespace sofapython3
 {

--- a/Plugin/src/SofaPython3/PythonTestExtractor.cpp
+++ b/Plugin/src/SofaPython3/PythonTestExtractor.cpp
@@ -34,6 +34,8 @@ using sofa::helper::system::PluginManager;
 using sofa::helper::system::SetDirectory;
 namespace py = pybind11;
 
+#include <list>
+
 namespace sofapython3 {
 // extract the test suite from a module
 py::object PythonTestExtractor::getTestSuite(py::module& unittest, py::module& module, const std::vector<std::string>& arguments)


### PR DESCRIPTION
No more dependency on boost's libraries (sofa will continue to use header-only lib however)