### PR TITLE
[Binding/Sofa.Core] Implement a custom getClassName() for trampoline classes.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -45,6 +45,8 @@ public:
     void reinit() override;
     void handleEvent(sofa::core::objectmodel::Event* event) override;
 
+    std::string getClassName() const override;
+
 private:
     void callScriptMethod(const pybind11::object& self, sofa::core::objectmodel::Event* event,
         const std::string& methodName);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -34,67 +34,75 @@ namespace py { using namespace pybind11; }
 
 namespace sofapython3
 {
-    using sofa::core::objectmodel::Event;
-    using sofa::core::DataEngine;
-    using sofa::core::objectmodel::BaseData;
-    using sofa::core::objectmodel::BaseObject;
-    using sofa::core::objectmodel::DDGNode;
+using sofa::core::objectmodel::Event;
+using sofa::core::DataEngine;
+using sofa::core::objectmodel::BaseData;
+using sofa::core::objectmodel::BaseObject;
+using sofa::core::objectmodel::DDGNode;
 
-    void DataEngine_Trampoline::init()
-    {
-        PythonEnvironment::gil acquire;
-        PYBIND11_OVERLOAD(void, DataEngine, init, );
-    }
+std::string DataEngine_Trampoline::getClassName() const
+{
+    PythonEnvironment::gil acquire {"getClassName"};
 
-    void DataEngine_Trampoline::doUpdate()
-    {
-        PythonEnvironment::gil acquire;
-        py::object self = py::cast(this);
-        if (py::hasattr(self, "update")) {
-            py::object fct = self.attr("update");
-            try {
-                fct();
-                return;
-            } catch (std::exception& /*e*/) {
-                throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type");
-            }
+    // Get the actual class name from python.
+    return py::str(py::cast(this).get_type().attr("__name__"));
+}
+
+void DataEngine_Trampoline::init()
+{
+    PythonEnvironment::gil acquire;
+    PYBIND11_OVERLOAD(void, DataEngine, init, );
+}
+
+void DataEngine_Trampoline::doUpdate()
+{
+    PythonEnvironment::gil acquire;
+    py::object self = py::cast(this);
+    if (py::hasattr(self, "update")) {
+        py::object fct = self.attr("update");
+        try {
+            fct();
+            return;
+        } catch (std::exception& /*e*/) {
+            throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type");
         }
-        throw py::type_error(this->getName() + " has no update() method.");
     }
+    throw py::type_error(this->getName() + " has no update() method.");
+}
 
-    void moduleAddDataEngine(pybind11::module &m)
-    {
-        py::class_<DataEngine,
-                DataEngine_Trampoline,
-                BaseObject,
-                py_shared_ptr<DataEngine>> f(m, "DataEngine",
-                                               py::dynamic_attr(),
-                                               sofapython3::doc::dataengine::DataEngine);
+void moduleAddDataEngine(pybind11::module &m)
+{
+    py::class_<DataEngine,
+            DataEngine_Trampoline,
+            BaseObject,
+            py_shared_ptr<DataEngine>> f(m, "DataEngine",
+                                         py::dynamic_attr(),
+                                         sofapython3::doc::dataengine::DataEngine);
 
-        f.def(py::init([](py::args& /*args*/, py::kwargs& kwargs)
-        {
-                  auto c = new DataEngine_Trampoline();
+    f.def(py::init([](py::args& /*args*/, py::kwargs& kwargs)
+          {
+              auto c = new DataEngine_Trampoline();
 
-                  for(auto kv : kwargs)
-                  {
-                      std::string key = py::cast<std::string>(kv.first);
-                      py::object value = py::reinterpret_borrow<py::object>(kv.second);
+              for(auto kv : kwargs)
+              {
+                  std::string key = py::cast<std::string>(kv.first);
+                  py::object value = py::reinterpret_borrow<py::object>(kv.second);
 
-                      if( key == "name")
-                      c->setName(py::cast<std::string>(kv.second));
-                      try {
-                          BindingBase::SetAttr(*c, key, value);
-                      } catch (py::attribute_error& /*e*/) {
-                          /// kwargs are used to set datafields to their initial values,
-                          /// but they can also be used as simple python attributes, unrelated to SOFA.
-                          /// thus we catch & ignore the py::attribute_error thrown by SetAttr
-                      }
+                  if( key == "name")
+                  c->setName(py::cast<std::string>(kv.second));
+                  try {
+                      BindingBase::SetAttr(*c, key, value);
+                  } catch (py::attribute_error& /*e*/) {
+                      /// kwargs are used to set datafields to their initial values,
+                      /// but they can also be used as simple python attributes, unrelated to SOFA.
+                      /// thus we catch & ignore the py::attribute_error thrown by SetAttr
                   }
-                  return c;
-              }));
+              }
+              return c;
+          }));
 
-        f.def("addInput", &DataEngine::addInput, sofapython3::doc::dataengine::addInput);
-        f.def("addOutput", &DataEngine::addOutput, sofapython3::doc::dataengine::addOutput);
-    }
+    f.def("addInput", &DataEngine::addInput, sofapython3::doc::dataengine::addInput);
+    f.def("addOutput", &DataEngine::addOutput, sofapython3::doc::dataengine::addOutput);
+}
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
@@ -32,6 +32,7 @@ public:
     void init() override;
     void doUpdate() override;
 
+    std::string getClassName() const override;
 };
 
 void moduleAddDataEngine(pybind11::module &m);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -59,6 +59,15 @@ namespace sofapython3
     ForceField_Trampoline<TDOFType>::~ForceField_Trampoline() = default;
 
     template<class TDOFType>
+    std::string ForceField_Trampoline<TDOFType>::getClassName() const
+    {
+        PythonEnvironment::gil acquire {"getClassName"};
+
+        // Get the actual class name from python.
+        return py::str(py::cast(this).get_type().attr("__name__"));
+    }
+
+    template<class TDOFType>
     void ForceField_Trampoline<TDOFType>::init()
     {
         ForceField<TDOFType>::init();

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
@@ -42,6 +42,7 @@ public:
     ~ForceField_Trampoline() override;
 
     void init() override;
+    std::string getClassName() const override;
 
     void addForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
     void addDForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx ) override;


### PR DESCRIPTION
Trampoline classes are used to implement sofa components in python.

When used, the default getClassName() (what is showed in the GUI) returns the name of the c++ trampoline class name instead
of the name of the python overrides.

This is why you can see stuff like that in the GUI:
```
Controller_Trampoline(myObject)
ForceField_Trampoline(myFF)
```

This PR change this behavior to retrieve the real class name from python and returns it in getClassName.
So python code like that:
```
class RoboticsController(Sofa.Core.Controller):
	pass
```

Will appears with its real name in the GUI:
```
RoboticController(myObject)
```