### PR TITLE
[SofaPython3/Plugin] Restore the automatic reload of modules

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -235,17 +235,8 @@ void PythonEnvironment::Init()
     // Lastly, we (try to) add modules from the root of SOFA
     addPythonModulePathsFromDirectory( Utils::getSofaPathPrefix() );
 
-    try
-    {
-        py::module::import("SofaRuntime");
-    }
-    catch (pybind11::error_already_set)
-    {
-        msg_error("SofaPython3") << "Could not import SofaRuntime module, initializing python3 for SOFA is not possible";
-        return;
-    }
     getStaticData()->m_sofamodule = py::module::import("Sofa");
-
+    PyRun_SimpleString("import SofaRuntime");
 
     // python livecoding related
     PyRun_SimpleString("from Sofa.livecoding import onReimpAFile");

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -131,8 +131,10 @@ SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& 
     if (globals == nullptr)
         globals = &globs;
     py::eval<py::eval_statements>(            // tell eval we're passing multiple statements
-                                              "import imp\n"
-                                              "new_module = imp.load_module(module_name, open(path), path, ('py', 'U', imp.PY_SOURCE))\n",
+                                              "import importlib.util \n"
+                                              "spec = importlib.util.spec_from_file_location(module_name, path) \n"
+                                              "new_module = importlib.util.module_from_spec(spec) \n"
+                                              "spec.loader.exec_module(new_module)",
                                               *globals,
                                               locals);
     py::module m =  py::cast<py::module>(locals["new_module"]);
@@ -251,7 +253,7 @@ void PythonEnvironment::Init()
     // general sofa-python stuff
 
     // python modules are automatically reloaded at each scene loading
-    //setAutomaticModuleReload( true );
+    setAutomaticModuleReload( true );
 
     // Initialize pluginLibraryPath by reading PluginManager's map
     std::map<std::string, Plugin>& map = PluginManager::getInstance().getPluginMap();


### PR DESCRIPTION
it is important when reloading a scene to force python to reload all the loaded modules to be sure the context is as clean as possible.

This PR restore this mechanism and clean the duplicated code from between SofaRuntime and Sofa