### PR TITLE
[Binding/Sofa.Config] Add Sofa.future & Sofa.Config 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ if (NOT SP3_COMPILED_AS_SUBPROJECT)
     message(STATUS "SOFA Framework:\n\tVersion: ${SofaFramework_VERSION}\n\tLocation: ${SOFA_ROOT_DIR}")
 endif()
 
+add_subdirectory(Config)
 add_subdirectory(Plugin)
 add_subdirectory(bindings)
 add_subdirectory(examples)

--- a/Config/CMakeLists.txt
+++ b/Config/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(Config VERSION 1.0)
+
+set(HEADER_FILES
+     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Config/futurefeatures.h
+)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Config/futurefeatures.cpp
+)
+
+find_package(SofaFramework REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+add_library(SofaPython3::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore)
+
+sofa_create_component_in_package_with_targets(
+    COMPONENT_NAME ${PROJECT_NAME}
+    COMPONENT_VERSION ${SofaPython3_VERSION}
+    PACKAGE_NAME SofaPython3
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    INCLUDE_SOURCE_DIR "src"
+    INCLUDE_INSTALL_DIR "."
+    OPTIMIZE_BUILD_DIR FALSE
+    RELOCATABLE ".."
+    )

--- a/Config/ConfigConfig.cmake.in
+++ b/Config/ConfigConfig.cmake.in
@@ -1,0 +1,22 @@
+# CMake package configuration file for the @PROJECT_NAME@ module
+@PACKAGE_GUARD@
+@PACKAGE_INIT@
+
+set(SP3_BUILD_TEST @SP3_BUILD_TEST@)
+
+find_package(pybind11 CONFIG REQUIRED)
+find_package(SofaFramework REQUIRED)
+find_package(SofaSimulationGraph REQUIRED)
+
+if(SP3_BUILD_TEST)
+    find_package(Sofa.Testing REQUIRED)
+endif()
+
+# If we are importing this config file and the target is not yet there this is indicating that
+# target is an imported one. So we include it
+if(NOT TARGET @PROJECT_NAME@)
+    include("${CMAKE_CURRENT_LIST_DIR}/PluginTargets.cmake")
+endif()
+
+# Check that the component/target is there.
+check_required_components(@PROJECT_NAME@)

--- a/Config/src/SofaPython3/Config/futurefeatures.cpp
+++ b/Config/src/SofaPython3/Config/futurefeatures.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <SofaPython3/Config/futurefeatures.h>
+
+namespace sofapython3::config::futurefeatures
+{
+
+std::map<std::string, bool> features;
+
+bool get(const std::string& name)
+{
+    auto f = features.find(name);
+    if(f == features.end())
+        throw std::runtime_error("Missing attribute '"+name+"'");
+
+    return (f->second);
+}
+
+void set(const std::string& name, bool value)
+{
+    auto f = features.find(name);
+    if(f == features.end())
+        throw std::runtime_error("Missing attribute '"+name+"'");
+
+    (f->second) = value;
+}
+
+void init(const std::string& name, bool value)
+{
+    features[name] = value;
+}
+
+
+std::vector<std::string> list_features()
+{
+    std::vector<std::string> v;
+    for(auto& it : features)
+        v.push_back(it.first);
+    return v;
+}
+
+}  //namespace sofapython3::futurefeatures

--- a/Config/src/SofaPython3/Config/futurefeatures.h
+++ b/Config/src/SofaPython3/Config/futurefeatures.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <sofa/config.h>
+#include <string>
+#include <vector>
+
+namespace sofapython3::config::futurefeatures
+{
+
+/// Retrieve the value associated with the feature "name"
+/// raise an exception if "name" is not existing.
+SOFA_EXPORT_DYNAMIC_LIBRARY bool get(const std::string& name);
+
+/// Change the value associated with the feature "name"
+/// raise an exception if "name" is not existing.
+SOFA_EXPORT_DYNAMIC_LIBRARY void set(const std::string& name, bool value);
+
+/// Create and set a new value for feature with "name"
+SOFA_EXPORT_DYNAMIC_LIBRARY void init(const std::string& name, bool value);
+
+/// Returns the list of registered features names
+SOFA_EXPORT_DYNAMIC_LIBRARY std::vector<std::string> list_features();
+
+} ///namespace  sofapython3::futurefeatures

--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(Bindings.Sofa)
 
 set(SOFABINDINGS_MODULE_LIST
+    Config
     Components
     Core
     Helper

--- a/bindings/Sofa/package/__futurefeatures__.py
+++ b/bindings/Sofa/package/__futurefeatures__.py
@@ -1,0 +1,3 @@
+import Sofa
+
+

--- a/bindings/Sofa/package/__futurefeatures__.py
+++ b/bindings/Sofa/package/__futurefeatures__.py
@@ -1,3 +1,0 @@
-import Sofa
-
-

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -37,14 +37,15 @@ import importlib
 import Sofa.constants
 import Sofa.Helper
 import Sofa.Core
+import Sofa.Config
 import Sofa.Simulation
 import Sofa.Types
 import Sofa.Components
 import SofaTypes
-
 from .prefab import *
+from .future import __enable_feature__
 
-__all__=["constants", "Helper", "Core", "Simulation", "Types", "SofaTypes", "prefab", "__futurefeatures__"]
+__all__=["constants", "Helper", "Core", "Simulation", "Types", "SofaTypes", "prefab", "future"]
 
 # Keep a list of the modules always imported in the Sofa-PythonEnvironment
 try:
@@ -55,7 +56,6 @@ except:
     # some modules could be added here manually and can be modified procedurally
     # e.g. plugin's modules defined from c++
     __SofaPythonEnvironment_modulesExcludedFromReload = []
-
 
 def unloadModules():
     """ call this function to unload python modules and to force their reload

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -44,7 +44,7 @@ import SofaTypes
 
 from .prefab import *
 
-__all__=["constants", "Helper", "Core", "Simulation", "Types", "SofaTypes", "prefab"]
+__all__=["constants", "Helper", "Core", "Simulation", "Types", "SofaTypes", "prefab", "__futurefeatures__"]
 
 # Keep a list of the modules always imported in the Sofa-PythonEnvironment
 try:

--- a/bindings/Sofa/package/future.py
+++ b/bindings/Sofa/package/future.py
@@ -1,0 +1,43 @@
+"""
+Activate/deactive some feature of sofa python
+
+Use that to control how some part of the binding should behave.
+
+Usage:
+    from Sofa.future import __enable_feature__
+
+    with __enable_feature__("feature_name", True):
+        do_something()
+
+    with __enable_feature__("feature_name", False):
+            do_something()
+"""
+import Sofa.Config
+from contextlib import ContextDecorator
+
+### Initialize the feature set.
+Sofa.Config.init("object_auto_init", False)
+# Add your own feature by un-commenting the following line
+#Sofa.Config.init("my_feature", False)
+
+def list_features():
+    return Sofa.Config.list_features()
+
+class __enable_feature__(ContextDecorator):
+        @staticmethod
+        def list_features():
+            return self.Config.list_feature()
+
+        def __init__(self, name, value):
+            self.name=name
+            self.new_value=value
+            self.old_value=None
+
+        def __enter__(self):
+            self.old_value=Sofa.Config.get(self.name)
+            Sofa.Config.set(self.name, self.new_value)
+            return self
+
+        def __exit__(self, *exc):
+            Sofa.Config.set(self.name, self.old_value)
+            return False

--- a/bindings/Sofa/src/SofaPython3/Sofa/Config/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Config/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(Bindings.Sofa.Config)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Config.cpp
+    )
+
+if (NOT TARGET SofaPython3::Plugin)
+    find_package(SofaPython3 REQUIRED)
+endif()
+
+find_package(Sofa.Config REQUIRED)
+find_package(SofaFramework REQUIRED)
+find_package(SofaBaseCollision REQUIRED)
+find_package(SofaBaseVisual REQUIRED)
+find_package(SofaBaseUtils REQUIRED)
+
+SP3_add_python_module(
+    TARGET       ${PROJECT_NAME}
+    PACKAGE      Bindings
+    MODULE       Config
+    DESTINATION  Sofa
+    SOURCES      ${SOURCE_FILES}
+    HEADERS      ${HEADER_FILES}
+    DEPENDS      Sofa.Config SofaBaseUtils SofaBaseCollision SofaCore SofaHelper SofaSimulationCore SofaDefaultType SofaBaseVisual SofaPython3::Config SofaPython3::Plugin
+)
+

--- a/bindings/Sofa/src/SofaPython3/Sofa/Config/Submodule_Config.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Config/Submodule_Config.cpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <iostream>
+#include <map>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <SofaPython3/Config/futurefeatures.h>
+
+namespace py { using namespace pybind11; }
+
+namespace sofapython3
+{
+
+/// The first parameter must be named the same as the module file to load.
+PYBIND11_MODULE(Config, ffmodule)
+{
+    ffmodule.doc() = R"doc(
+           Control the the activation of new features
+           ------------------------------------------
+           Sofa.Config.object_auto_init = True
+       )doc";
+    ffmodule.def("init", sofapython3::config::futurefeatures::init);
+    ffmodule.def("set", sofapython3::config::futurefeatures::set);
+    ffmodule.def("get", sofapython3::config::futurefeatures::get);
+    ffmodule.def("list_features", sofapython3::config::futurefeatures::list_features);
+}
+
+} ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -85,5 +85,5 @@ SP3_add_python_module(
     DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      SofaBaseUtils SofaBaseCollision SofaCore SofaHelper SofaSimulationCore SofaDefaultType SofaBaseVisual SofaPython3::Plugin
+    DEPENDS      SofaBaseUtils SofaBaseCollision SofaCore SofaHelper SofaSimulationCore SofaDefaultType SofaBaseVisual SofaPython3::Config SofaPython3::Plugin
 )

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCE_FILES
 
 set(PYTHON_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Components/Components.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/Config/Config.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseData.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Base.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseObject.py
@@ -51,6 +52,7 @@ add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
 set(DIR_BINDING_LIST
     Components
+    Config
     Core
     Helper
     Simulation

--- a/bindings/Sofa/tests/Config/Config.py
+++ b/bindings/Sofa/tests/Config/Config.py
@@ -1,0 +1,15 @@
+# coding: utf8
+
+import Sofa.Config
+from Sofa.future import __enable_feature__
+import unittest
+
+class Test(unittest.TestCase):
+    def test_init_feature(self):
+        Sofa.Config.init("new_feature", False)
+        self.assertFalse(Sofa.Config.get("new_feature"), False)
+
+        with __enable_feature__("new_feature", True):
+            self.assertEquals(Sofa.Config.get("new_feature"), True)
+
+        self.assertFalse(Sofa.Config.get("new_feature"), False)

--- a/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
+++ b/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
@@ -54,6 +54,7 @@ static struct PythonModule_Sofa_tests : public PythonTestExtractor
     PythonModule_Sofa_tests()
     {
         const std::string executable_directory = sofa::helper::Utils::getExecutableDirectory();
+        addTestDirectory(executable_directory+"/Config", "Sofa_Config_");
         addTestDirectory(executable_directory+"/Core", "Sofa_Core_");
         addTestDirectory(executable_directory+"/Helper", "Sofa_Helper_");
         addTestDirectory(executable_directory+"/Simulation", "Sofa_Simulation_");


### PR DESCRIPTION
Implement a control mecanism to activate/de-activate feature of the SofaPython3 binding so we have more freedom 
to experiment. 

Example of use (taken from PR #173):
```python

from Sofa.future import __enable_feature__
def createScene(root):
     with __enable_feature__("object_auto_init",True):
           root.addObject("MechanicalObject", position=[12,3])  # init() is now called automatically
```
