### PR TITLE
[Plugin] Add calling point for the msg_deprecated emitted by PythonFactory;

### DIFF
--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -51,6 +51,8 @@ using sofa::core::objectmodel::MouseEvent;
 using sofa::core::objectmodel::ScriptEvent;
 using sofa::core::objectmodel::Event;
 
+#include <SofaPython3/PythonEnvironment.h>
+
 #include <sofa/core/topology/Topology.h>
 
 #include <sofa/defaulttype/DataTypeInfo.h>
@@ -346,7 +348,8 @@ void PythonFactory::fromPython(BaseData* d, const py::object& o)
     {
         msg_deprecated(d->getOwner()) << "Data field '" << d->getName() << "' is initialized from a string."
                                       << " This behavior was allowed with SofaPython2 but have very poor performance so it is now "
-                                      << "deprecated with SofaPython3. Please fix your scene (as this behavior will be removed).";
+                                      << "deprecated with SofaPython3. Please fix your scene (as this behavior will be removed)."
+                                      << PythonEnvironment::getPythonCallingPointString();
         d->read( py::cast<std::string>(o) );
         return;
     }


### PR DESCRIPTION
So now when a PythonFactory actions fails... it provide the filename & line number from where it is emitted. 