### PR TITLE
[SofaPython3] Add in DataHelper dedicated to-string conversion from basedata

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -43,9 +43,17 @@ std::string toSofaParsableString(const py::handle& p)
         }
         return tmp.str();
     }
+
     //TODO(dmarchal) This conversion to string is so bad.
     if(py::isinstance<py::str>(p))
         return py::str(p);
+
+    // Insure compatibility with data field code returning value instead of data.
+    if(py::isinstance<sofa::core::objectmodel::BaseData>(p))
+    {
+        sofa::core::objectmodel::BaseData* data = py::cast<sofa::core::objectmodel::BaseData*>(p);
+        return data->getValueString();
+    }
     return py::repr(p);
 }
 


### PR DESCRIPTION
In SofaPython it was possible do write: 
node.createObject("MechanicalObejct", position=loader.position) 
This was working as loader.position was returning the values of the data field. 

In SofaPython3 ithis will fails as loader.position is not returning anymore the values but the data:
node.createObject("MechanicalObejct", position=loader.position) 
  

Object creation is still using a systematic to-string conversion (see PR #45), so the data are converted to string using the "repr" operator which does not necesserly generate a sofa-compatible string. 
When the object to convert is a BaseData... it is much better to rely on the getValueString() fonction which returns a string compatible with sofa. 
 