### PR TITLE
[Win/MSVC] Fix search of modules

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -227,7 +227,11 @@ void PythonEnvironment::Init()
         }
     }
 
+    // Add sites-packages wrt the plugin
     addPythonModulePathsForPluginsByName("SofaPython3");
+
+    // Lastly, we (try to) add modules from the root of sofa
+    addPythonModulePathsFromSofaRoot();
 
     py::module::import("SofaRuntime");
     getStaticData()->m_sofamodule = py::module::import("Sofa");
@@ -361,6 +365,19 @@ void PythonEnvironment::addPythonModulePathsForPluginsByName(const std::string& 
         }
     }
     msg_info("SofaPython3") << pluginName << " not found in PluginManager's map.";
+}
+
+void PythonEnvironment::addPythonModulePathsFromSofaRoot()
+{
+    // this will either use SOFA_ROOT (very often in install mode) 
+    // or if SOFA_ROOT is not set (very often in build-mode), using the root of the build-dir
+    // to find /lib/python3/site-packages
+    const auto sofaRoot = Utils::getSofaPathPrefix();
+
+    if (FileSystem::exists(sofaRoot + "/lib/python3/site-packages"))
+    {
+        addPythonModulePath(sofaRoot + "/lib/python3/site-packages");
+    }
 }
 
 void PythonEnvironment::addPluginManagerCallback()

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -72,6 +72,7 @@ public:
     /// NB: can also be used for projects <projectDirectory>/*/python
     static void addPythonModulePathsForPlugins(const std::string& pluginsDirectory);    
     static void addPythonModulePathsForPluginsByName(const std::string& pluginName);
+    static void addPythonModulePathsFromSofaRoot();
 
     /// set the content of sys.argv.
     static void setArguments(const std::string& filename,


### PR DESCRIPTION
Fix #159  by searching the lib/python3/sites_packages directly from:
 - SOFA_ROOT if it exists
 - the root of SOFA (given by Utils::getSofaPathPrefix), useful when working with build dir (and not setting SOFA_ROOT)
(avoiding the mess of Release/Debug directory in bin)

The total fix for loading SofaPython3, from a build with Windows and MSVC still needs a fix to fix the issue of the .py files dispatched in `<root>/python3/sites_packages` and the .pyd in `<root>/lib/python3/sites_packages` (as reported by #186)