### PR TITLE
[SofaPython3/splib] Add a gentle deprecation message and info on how to find the SPLIB.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,16 @@ SP3_add_python_package(
         Sofa/constants
 )
 
+## This is only to warn users that splib is now relocated in its own repository
+# it just contains a __init__.py rising an exception indicating to where to find the plugin.
+# If splib is available, then splib/__init__.py will be overriden by the one from the real splib.
+SP3_add_python_package(
+    SOURCE_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}/splib
+    TARGET_DIRECTORY
+        splib
+)
+
 sofa_create_package(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${PROJECT_VERSION}

--- a/splib/__init__.py
+++ b/splib/__init__.py
@@ -1,0 +1,4 @@
+"""SPLIB is now relocated at: https://github.com/SofaDefrost/STLIB, please clone and install the plugin to use it"""
+raise Exception("SPLIB is now relocated at: https://github.com/SofaDefrost/STLIB, please clone and install the plugin to use it")
+
+


### PR DESCRIPTION
In initial version of SofaPython3 there was a partial version of SPLIB that was removed. 

If someone still do an import splib expecting to rely on the one in SofaPython3 it will get and error saying splib is missing.
In this PR we have added a fake splib file so importing it results in an exception indicating how to install it. 
