### PR TITLE
[Sofa.Core.BaseData] Add to the binding a method BaseData::setParent from a link path

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
@@ -147,6 +147,11 @@ void setParent(BaseData* self, BaseData* parent)
     self->setParent(parent);
 }
 
+void setParentFromLinkPath(BaseData* self, const std::string& parent)
+{
+    self->setParent(parent);
+}
+
 bool hasParent(BaseData *self)
 {
     return (self->getParent() != nullptr);
@@ -196,6 +201,7 @@ void moduleAddBaseData(py::module& m)
     data.def("isPersistent", &BaseData::isPersistent, sofapython3::doc::baseData::isPersistent);
     data.def("setPersistent", &BaseData::setPersistent, sofapython3::doc::baseData::setPersistent);
     data.def("setParent", setParent, sofapython3::doc::baseData::setParent);
+    data.def("setParent", setParentFromLinkPath, sofapython3::doc::baseData::setParent);
     data.def("hasParent", hasParent, sofapython3::doc::baseData::hasParent);
     data.def("read", &BaseData::read, sofapython3::doc::baseData::read);
     data.def("updateIfDirty", updateIfDirty, sofapython3::doc::baseData::updateIfDirty);


### PR DESCRIPTION
Currently it is possible to set a parent by calling:
```python
oneData.setParent(otherData) 
```

With the PR it become possible to do 
```python
oneData.setParent("@/myobjcet.data") 
```

It is questionnable wether we want such behavior or not, but as long as lazy-string link making is allowed in Sofa.core it make sense to have it in the binding. 