### PR TITLE
[Sofa.Core.Binding] Remove suprious exception handler in Binding_DataEngine

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -270,7 +270,8 @@ void executePython_(const T& emitter, std::function<void()> cb)
         std::stringstream tmp;
         tmp << "Unable to execute code." << msgendl
                      << "Python exception:" << msgendl
-                     << "  " << e.what();
+                     << "  " << e.what()
+                     << PythonEnvironment::getPythonCallingPointString();
         msg_error(emitter) << tmp.str();
     }
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -61,7 +61,7 @@ void DataEngine_Trampoline::doUpdate()
         py::object self = py::cast(this);
         if (py::hasattr(self, "update"))
         {
-            py::object fct = self.attr("update")();
+            py::object fct = self.attr("update");
             fct();
             return;
         }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -59,14 +59,11 @@ void DataEngine_Trampoline::doUpdate()
 {
     PythonEnvironment::executePython(this, [this](){
         py::object self = py::cast(this);
-        if (py::hasattr(self, "update")) {
-            py::object fct = self.attr("update");
-            try {
-                fct();
-                return;
-            } catch (std::exception& /*e*/) {
-                throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type");
-            }
+        if (py::hasattr(self, "update"))
+        {
+            py::object fct = self.attr("update")();
+            fct();
+            return;
         }
         throw py::type_error(this->getName() + " has no update() method.");
     });


### PR DESCRIPTION
The current exception handler in the DataEngine binding is misleading as it
convert every exceptions into one saying:
"The DataEngine requires an update method with no parameter and no return type"

This is wrong. 
It is better to let the original exception propagate.