### PR TITLE
[Plugin] Report back to SOFA if a problem arises when initializing python3 environment

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -233,7 +233,15 @@ void PythonEnvironment::Init()
     // Lastly, we (try to) add modules from the root of SOFA
     addPythonModulePathsFromDirectory( Utils::getSofaPathPrefix() );
 
-    py::module::import("SofaRuntime");
+    try
+    {
+        py::module::import("SofaRuntime");
+    }
+    catch (pybind11::error_already_set)
+    {
+        msg_error("SofaPython3") << "Could not import SofaRuntime module, initializing python3 for SOFA is not possible";
+        return;
+    }
     getStaticData()->m_sofamodule = py::module::import("Sofa");
 
 
@@ -255,6 +263,8 @@ void PythonEnvironment::Init()
             pluginLibraryPath = elem.first;
         }
     }
+
+    s_isInitialized = true;
 }
 
 // Single implementation for the three different versions

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -59,6 +59,11 @@ public:
     static void Init();
     static void Release();
 
+    static bool isInitialized()
+    {
+        return s_isInitialized;
+    };
+
     static pybind11::module importFromFile(const std::string& module,
                                      const std::string& path,
                                      pybind11::object* globals = nullptr);
@@ -150,6 +155,7 @@ public:
 private:
     static PythonEnvironmentData* getStaticData() ;
     static std::string pluginLibraryPath;
+    static inline bool s_isInitialized{false};
 };
 
 } // namespace sofapython3

--- a/Plugin/src/SofaPython3/initModule.cpp
+++ b/Plugin/src/SofaPython3/initModule.cpp
@@ -37,6 +37,7 @@ SOFAPYTHON3_API const char* getModuleVersion();
 SOFAPYTHON3_API const char* getModuleLicense();
 SOFAPYTHON3_API const char* getModuleDescription();
 SOFAPYTHON3_API const char* getModuleComponentList();
+SOFAPYTHON3_API bool moduleIsInitialized();
 
 void initExternalModule()
 {
@@ -78,6 +79,11 @@ const char* getModuleDescription()
 const char* getModuleComponentList()
 {
     return "";
+}
+
+bool moduleIsInitialized()
+{
+    return PythonEnvironment::isInitialized();
 }
 
 }


### PR DESCRIPTION
Needs https://github.com/sofa-framework/sofa/pull/2425 to be useful.

If PythonEnvironment::Init() cannot import SofaRuntime, then catch the error and report that SofaPython3 is not initalized