### PR TITLE
Fix for pybind version >= 2.8.1

### DIFF
--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -57,8 +57,8 @@ using sofa::core::objectmodel::Event;
 
 #include <sofa/defaulttype/DataTypeInfo.h>
 
-/// Bind the python's attribute error
-namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
 

--- a/Plugin/src/SofaPython3/config.h
+++ b/Plugin/src/SofaPython3/config.h
@@ -38,3 +38,11 @@
 #else
 	#define SOFAPYTHON3_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
+
+// pybind11 already bind the attributeError starting from 2.8.1 version.
+// so if the version is >= 2.8.1, macro does nothing, otherwise bind attribute_error
+#if not(PYBIND11_VERSION_MAJOR >= 2 && PYBIND11_VERSION_MINOR >= 8 && PYBIND11_VERSION_PATCH >= 1)
+#define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR() namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+#else
+#define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+#endif // not(PYBIND11_VERSION >= 2.8.1)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -43,8 +43,7 @@ using sofa::simulation::Node;
 
 #include <SofaPython3/DataHelper.h>
 
-/// Bind the python's attribute error
-namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
 
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
@@ -33,8 +33,8 @@
 #include <SofaPython3/DataHelper.h>
 #include <SofaPython3/PythonFactory.h>
 
-/// Bind the python's attribute error
-namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -28,8 +28,8 @@
 #include <SofaPython3/PythonFactory.h>
 #include <SofaPython3/PythonEnvironment.h>
 
-/// Bind the python's attribute error
-namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -27,8 +27,8 @@ using sofapython3::PythonEnvironment;
 
 #include <pybind11/pybind11.h>
 
-/// Bind the python's attribute error
-namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -36,8 +36,8 @@ using sofa::simulation::VisualInitVisitor;
 using sofa::simulation::Simulation;
 
 
-/// Bind the python's attribute error
-namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
 /// To bring in the `_a` literal


### PR DESCRIPTION
Since the version 2.8.1, pybind is doing the binding on attributeError automatically.
(https://github.com/pybind/pybind11/commit/78ee782bd494debcbc166f717379a4f9c2093c0f)
It will be throw a compilation error in SofaPython3 because it was also bind here and there (`already defined` error)

This PR creates a macro (to avoid copy-paste) which, according to the version of pybind, bind or not the attribute_error.

I am also wondering if it was really necessary to do it in each binding_module (and PythonFactory.cpp) and why not once for all in the PythonFactory.h ?