### PR TITLE
[CI] FIX release tag name (do not use branch name)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,8 @@ jobs:
       - name: Upload release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          tag_name: release-${{ github.ref_name }}
           fail_on_unmatched_files: true
           files: |
             artifacts/SofaPython3_*_Linux.zip


### PR DESCRIPTION
Tags named as branches are not very helpful since they create usage conflicts and force the user to specify what he wants to manipulate between `refs/tags/something` (the tag) or `refs/heads/something` (the branch).