### PR TITLE
[Test] Fix Simulation.py test

### DIFF
--- a/bindings/Sofa/tests/Simulation/Simulation.py
+++ b/bindings/Sofa/tests/Simulation/Simulation.py
@@ -21,6 +21,7 @@ class Test(unittest.TestCase):
         tf = tempfile.NamedTemporaryFile(mode="w+t", suffix=".scn", delete=False)
         tf.write(scene)
         tf.flush()
+        tf.close() # need to close the file otherwise SOFA cannot open it (on Windows)
         node = Sofa.Simulation.load(tf.name)
         self.assertNotEqual(node, None)
         self.assertEqual(node.name.value, "rootNode")

--- a/examples/loadXMLfromPython.py
+++ b/examples/loadXMLfromPython.py
@@ -23,6 +23,7 @@ def createScene(root):
 	tf = tempfile.NamedTemporaryFile(mode="w+t", suffix=".scn", delete=False)
 	tf.write(scene)
 	tf.flush()
+	tf.close()
 	loaded_node = Sofa.Simulation.load(tf.name)
 	root.addChild(loaded_node)
 	os.remove(tf.name)


### PR DESCRIPTION
On Windows, the created temp file is not accessible for SOFA (therefore fails while trying to load the XML file), as it is being opened by the current process.
We just need to close it before giving it to Sofa.Simulation.init().

EDIT: same problem with loadXMLFromPython (in examples)

EDIT2: Fix #214 