### PR TITLE
[Plugin] Use non-deprecated header/class

### DIFF
--- a/Plugin/src/SofaPython3/PythonTest.cpp
+++ b/Plugin/src/SofaPython3/PythonTest.cpp
@@ -25,7 +25,7 @@ using namespace pybind11::literals; // to bring in the `_a` literal
 #include <pybind11/embed.h>
 namespace py = pybind11;
 
-#include <sofa/helper/testing/BaseTest.h>
+#include <sofa/testing/BaseTest.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <sofa/helper/system/FileSystem.h>
 

--- a/Plugin/src/SofaPython3/PythonTest.h
+++ b/Plugin/src/SofaPython3/PythonTest.h
@@ -22,7 +22,7 @@
 
 #include <string>
 #include <SofaPython3/config.h>
-#include <sofa/helper/testing/BaseTest.h>
+#include <sofa/testing/BaseTest.h>
 
 #include <filesystem>
 using std::filesystem::path;
@@ -30,7 +30,7 @@ using std::filesystem::path;
 namespace sofapython3
 {
 
-using sofa::helper::testing::BaseTest;
+using sofa::testing::BaseTest;
 
 /// a Python_test is defined by a python filepath and optional arguments
 struct SOFAPYTHON3_API PythonTestData

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -133,7 +133,7 @@ namespace sofapython3
     void ForceField_Trampoline<TDOFType>::addKToMatrix(const MechanicalParams* mparams, const MultiMatrixAccessor* dfId)
     {
         MultiMatrixAccessor::MatrixRef mref = dfId->getMatrix(this->mstate);
-        sofa::defaulttype::BaseMatrix* mat = mref.matrix;
+        sofa::linearalgebra::BaseMatrix* mat = mref.matrix;
 
         size_t offset = mref.offset;
         // nNodes is the number of nodes (positions) of the object whose K matrix we're computing


### PR DESCRIPTION
Some deprecated testing headers are used, so this PR change those to the normal ones.

(those headers will be disabled in a PR in SOFA, before v21.12 release)