### PR TITLE
Fix test on pybind version

### DIFF
--- a/Plugin/src/SofaPython3/config.h
+++ b/Plugin/src/SofaPython3/config.h
@@ -39,10 +39,14 @@
 	#define SOFAPYTHON3_API SOFA_IMPORT_DYNAMIC_LIBRARY
 #endif
 
+// define own pybind version macro, much easier to test/read
+#define PYBIND11_SOFA_VERSION (PYBIND11_VERSION_MAJOR * 10000 \
+    + PYBIND11_VERSION_MINOR * 100 \
+    + PYBIND11_VERSION_PATCH)
 // pybind11 already bind the attributeError starting from 2.8.1 version.
 // so if the version is >= 2.8.1, macro does nothing, otherwise bind attribute_error
-#if not(PYBIND11_VERSION_MAJOR >= 2 && PYBIND11_VERSION_MINOR >= 8 && PYBIND11_VERSION_PATCH >= 1)
-#define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR() namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
-#else
+#if PYBIND11_SOFA_VERSION >= 20801
 #define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
-#endif // not(PYBIND11_VERSION >= 2.8.1)
+#else
+#define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR() namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
+#endif // PYBIND11_SOFA_VERSION >= 20801


### PR DESCRIPTION
Fix test introduced on pybind version in #216 

It was failing with version v2.9.0.

Introduced a new macro to test the version against, easier to read and less error-prone.