### PR TITLE
Set SOFA_ROOT if not set and successfully guessed

### DIFF
--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -53,23 +53,24 @@ else:
         print("Warning: cannot guess SOFA_ROOT", 
         "Loading SOFA libraries will likely fail and/or SOFA won't find its resources.")
 
-# check if SOFAPYTHON3_ROOT has been (well) set
-sofapython3_root = os.environ.get('SOFAPYTHON3_ROOT')
-if sofapython3_root:
-    print("Using environment variable SOFAPYTHON3_ROOT: " + sofapython3_root)
-else:
-    print("Warning: environment variable SOFAPYTHON3_ROOT is empty. Trying to guess it.")
-    # try a guess from <sofapython3_root>/lib/python3/site-packages/Sofa
-    sofapython3_root_guess = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + '/../../../..') 
-    if os.path.isdir(os.path.abspath(sofapython3_root_guess + '/lib' )):
-        print("Guessed SOFAPYTHON3_ROOT: " + sofapython3_root_guess)
-        sofapython3_root = sofapython3_root_guess
-        os.environ["SOFAPYTHON3_ROOT"] = sofapython3_root
-    else:
-        print("Warning: cannot guess SOFAPYTHON3_ROOT", 
-        "Loading SofaPython3 modules will likely fail.")
-
 if sofa_root and sys.platform == 'win32':
+
+    # check if SOFAPYTHON3_ROOT has been (well) set, only useful for Windows
+    sofapython3_root = os.environ.get('SOFAPYTHON3_ROOT')
+    if sofapython3_root:
+        print("Using environment variable SOFAPYTHON3_ROOT: " + sofapython3_root)
+    else:
+        print("Warning: environment variable SOFAPYTHON3_ROOT is empty. Trying to guess it.")
+        # try a guess from <sofapython3_root>/lib/python3/site-packages/Sofa
+        sofapython3_root_guess = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + '/../../../..') 
+        if os.path.isdir(os.path.abspath(sofapython3_root_guess + '/lib' )):
+            print("Guessed SOFAPYTHON3_ROOT: " + sofapython3_root_guess)
+            sofapython3_root = sofapython3_root_guess
+            os.environ["SOFAPYTHON3_ROOT"] = sofapython3_root
+        else:
+            print("Warning: cannot guess SOFAPYTHON3_ROOT", 
+            "Loading SofaPython3 modules will likely fail.")
+
     # Windows-only: starting from python 3.8, python wont read the env. variable PATH to get SOFA's dlls. 
     # os.add_dll_directory() is the new way to add paths for python to get external libraries.
     sofa_bin_path = sofa_root + "\\bin"

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -48,6 +48,7 @@ else:
     if os.path.isdir(os.path.abspath(sofa_root_guess + '/lib' )):
         print("Guessed SOFA_ROOT: " + sofa_root_guess)
         sofa_root = sofa_root_guess
+        os.environ["SOFA_ROOT"] = sofa_root
     else:
         print("Warning: cannot guess SOFA_ROOT", 
         "Loading SOFA libraries will likely fail and/or SOFA won't find its resources.")
@@ -63,6 +64,7 @@ else:
     if os.path.isdir(os.path.abspath(sofapython3_root_guess + '/lib' )):
         print("Guessed SOFAPYTHON3_ROOT: " + sofapython3_root_guess)
         sofapython3_root = sofapython3_root_guess
+        os.environ["SOFAPYTHON3_ROOT"] = sofapython3_root
     else:
         print("Warning: cannot guess SOFAPYTHON3_ROOT", 
         "Loading SofaPython3 modules will likely fail.")


### PR DESCRIPTION
On linux (and mac) the process to guess SOFA_ROOT only print it but does not do anything with it...
So this PR set this value (while python is running) so Sofa under python can find its .so if SOFA_ROOT is not set.

~~(and set SOFAPYTHON3_ROOT as well but I dont know the use of this one)~~