### PR TITLE
[CI] Force SOFA scope to 'minimal'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}
+          sofa_scope: 'minimal'
       
       - name: Checkout source code
         uses: actions/checkout@v2


### PR DESCRIPTION
Now that the parameter `sofa_scope` of https://github.com/sofa-framework/sofa-setup-action is on 'standard' by default, we must force it to 'minimal' because SOFA 'standard' contains SP3 binaries.