### PR TITLE
Restore xml and python different naming conventions

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -214,7 +214,7 @@ py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs
 
     if (name.empty())
     {
-        const auto resolvedName = self->getNameHelper().resolveName(object->getClassName(), name);
+        const auto resolvedName = self->getNameHelper().resolveName(object->getClassName(), name, sofa::core::ComponentNameHelper::Convention::python);
         object->setName(resolvedName);
     }
 


### PR DESCRIPTION
For https://github.com/sofa-framework/sofa/pull/2773