### PR TITLE
[SofaPython3/Binding] Do not use the binding cache mecanisme when the data is dirty (Fix sofa issue #2761)

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -294,6 +294,8 @@ size_t getSize(BaseData* self)
 
 py::buffer_info toBufferInfo(BaseData& m)
 {
+    scoped_read_access guard(&m);
+
     const AbstractTypeInfo& nfo { *m.getValueTypeInfo() };
     auto itemNfo = nfo.BaseType();
 

--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -413,7 +413,7 @@ py::array resetArrayFor(BaseData* d)
 py::array getPythonArrayFor(BaseData* d)
 {
     auto& memcache = getObjectCache();
-    if(memcache.find(d) == memcache.end())
+    if(d->isDirty() || memcache.find(d) == memcache.end())
     {
         auto capsule = py::capsule(new Base::SPtr(d->getOwner()));
 


### PR DESCRIPTION
The problem in issue #2761 is related to how we get the raw pointer from sofa to python numpy array. 
If the data is dirty then the pointer was not the right one. 
Can you try it fix the issue 
@AlbanOdot @jnbrunet @fredroy ?

Fix https://github.com/sofa-framework/sofa/issues/2761