### PR TITLE
FIX PYBIND11_SOFA_VERSION

### DIFF
--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(Plugin VERSION 1.0)
 
 set(HEADER_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/config.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/initModule.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonEnvironment.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SceneLoaderPY3.h
@@ -43,6 +42,10 @@ find_package(pybind11 CONFIG REQUIRED)
 find_package(SofaFramework REQUIRED)
 find_package(SofaSimulationGraph REQUIRED)
 
+string(REPLACE "." "" PYBIND11_SOFA_VERSION ${pybind11_VERSION})
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/config.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/config.h")
+
+    
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 add_library(SofaPython3::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(Plugin VERSION 1.0)
 
 set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/config.h.in
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/initModule.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonEnvironment.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SceneLoaderPY3.h
@@ -41,10 +42,6 @@ endif(SP3_BUILD_TEST)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(SofaFramework REQUIRED)
 find_package(SofaSimulationGraph REQUIRED)
-
-string(REPLACE "." "" PYBIND11_SOFA_VERSION ${pybind11_VERSION})
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/config.h.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/config.h")
-
     
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 add_library(SofaPython3::${PROJECT_NAME} ALIAS ${PROJECT_NAME})

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -42,7 +42,7 @@ endif(SP3_BUILD_TEST)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(SofaFramework REQUIRED)
 find_package(SofaSimulationGraph REQUIRED)
-    
+
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 add_library(SofaPython3::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -81,6 +81,8 @@ set_target_properties(
         CUDA_VISIBILITY_PRESET "hidden"
 )
 
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>")
+
 sofa_create_component_in_package_with_targets(
     COMPONENT_NAME ${PROJECT_NAME}
     COMPONENT_VERSION ${SofaPython3_VERSION}

--- a/Plugin/src/SofaPython3/DataCache.h
+++ b/Plugin/src/SofaPython3/DataCache.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <pybind11/numpy.h>
-#include "config.h"
+#include <SofaPython3/config.h>
 
 ////////////////////////// FORWARD DECLARATION ///////////////////////////
 namespace sofa {

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -44,7 +44,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/eval.h>
 
-#include "config.h"
+#include <SofaPython3/config.h>
 
 namespace sofapython3
 {

--- a/Plugin/src/SofaPython3/PythonFactory.h
+++ b/Plugin/src/SofaPython3/PythonFactory.h
@@ -25,7 +25,7 @@
 #include <sofa/core/objectmodel/Base.h>
 #include <sofa/core/objectmodel/Event.h>
 #include <pybind11/pybind11.h>
-#include "config.h"
+#include <SofaPython3/config.h>
 
 /////////////////////////////// DECLARATION //////////////////////////////
 namespace sofapython3

--- a/Plugin/src/SofaPython3/SceneLoaderPY3.h
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.h
@@ -27,7 +27,7 @@
 #include <sofa/simulation/Visitor.h>
 #include <sofa/simulation/Node.h>
 
-#include "config.h"
+#include <SofaPython3/config.h>
 
 namespace sofapython3
 {

--- a/Plugin/src/SofaPython3/config.h
+++ b/Plugin/src/SofaPython3/config.h
@@ -41,8 +41,7 @@
 
 // define own pybind version macro, much easier to test/read
 #define PYBIND11_SOFA_VERSION (PYBIND11_VERSION_MAJOR * 10000 \
-    + PYBIND11_VERSION_MINOR * 100 \
-    + PYBIND11_VERSION_PATCH)
+    + PYBIND11_VERSION_MINOR * 100)
 // pybind11 already bind the attributeError starting from 2.8.1 version.
 // so if the version is >= 2.8.1, macro does nothing, otherwise bind attribute_error
 #if PYBIND11_SOFA_VERSION >= 20801

--- a/Plugin/src/SofaPython3/config.h.in
+++ b/Plugin/src/SofaPython3/config.h.in
@@ -40,11 +40,10 @@
 #endif
 
 // define own pybind version macro, much easier to test/read
-#define PYBIND11_SOFA_VERSION (PYBIND11_VERSION_MAJOR * 10000 \
-    + PYBIND11_VERSION_MINOR * 100)
+#define PYBIND11_SOFA_VERSION @PYBIND11_SOFA_VERSION@
 // pybind11 already bind the attributeError starting from 2.8.1 version.
 // so if the version is >= 2.8.1, macro does nothing, otherwise bind attribute_error
-#if PYBIND11_SOFA_VERSION >= 20801
+#if PYBIND11_SOFA_VERSION >= 2801
 #define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
 #else
 #define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR() namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }

--- a/Plugin/src/SofaPython3/config.h.in
+++ b/Plugin/src/SofaPython3/config.h.in
@@ -40,10 +40,17 @@
 #endif
 
 // define own pybind version macro, much easier to test/read
-#define PYBIND11_SOFA_VERSION @PYBIND11_SOFA_VERSION@
+#define PYBIND11_SOFA_VERSION_MAJOR @pybind11_VERSION_MAJOR@
+#define PYBIND11_SOFA_VERSION_MINOR @pybind11_VERSION_MINOR@
+#define PYBIND11_SOFA_VERSION_PATCH @pybind11_VERSION_PATCH@
+#define PYBIND11_SOFA_VERSION ( \
+      PYBIND11_SOFA_VERSION_MAJOR * 10000 \
+    + PYBIND11_SOFA_VERSION_MINOR * 100 \
+    + PYBIND11_SOFA_VERSION_PATCH )
+
 // pybind11 already bind the attributeError starting from 2.8.1 version.
 // so if the version is >= 2.8.1, macro does nothing, otherwise bind attribute_error
-#if PYBIND11_SOFA_VERSION >= 2801
+#if PYBIND11_SOFA_VERSION >= 20801
 #define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
 #else
 #define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR() namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }

--- a/Plugin/src/SofaPython3/initModule.cpp
+++ b/Plugin/src/SofaPython3/initModule.cpp
@@ -18,7 +18,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include "config.h"
+#include <SofaPython3/config.h>
 
 #include "PythonEnvironment.h"
 using sofapython3::PythonEnvironment;


### PR DESCRIPTION
fixes #235 

Building SofaPython3 with the master version of pybind11 (or any "non-release" version with a patch tag in PYBIND11_VERSION_PATCH) will cause a compile error, because the PYBIND11_SOFA_VERSION macro definition expects a number-only macro.

There are two solutions to this issue:
1. is the one I'm proposing in this PR: removing the patch number from PYBIND11_SOFA_VERSION. I don't think it is necessary in SOFA to know the patch version of pybind11, but I might be wrong...

2. updating the documentation for SofaPython3, to explicitly tell people to either install pybind11 from their system package manager, or tell them to checkout a release version of pybind11 if one wants to build it from its source repository.