### PR TITLE
[SofaPython3] Fix regression introduced in #PR182

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -130,8 +130,10 @@ SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& 
     py::object globs = py::globals();
     if (globals == nullptr)
         globals = &globs;
+
     py::eval<py::eval_statements>(            // tell eval we're passing multiple statements
                                               "import importlib.util \n"
+                                              "importlib.machinery.SOURCE_SUFFIXES.append('pyscn') \n"
                                               "spec = importlib.util.spec_from_file_location(module_name, path) \n"
                                               "new_module = importlib.util.module_from_spec(spec) \n"
                                               "spec.loader.exec_module(new_module)",


### PR DESCRIPTION
The python3 mecanisme used in place of python2's on is not handling pyscn by default.
Declaring .pyscn in the list of sources suffix is needed to make that possible.

@guparan can you review and merge plz ?