### PR TITLE
[Sofa.Core] Print the event when printLog is activated.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -64,6 +64,13 @@ void Controller_Trampoline::reinit()
 void Controller_Trampoline::callScriptMethod(
         const py::object& self, Event* event, const std::string & methodName)
 {
+    if(f_printLog.getValue())
+    {
+        std::string name = std::string("on")+event->getClassName();
+        std::string eventStr = py::str(PythonFactory::toPython(event));
+        msg_info() << name << " " << eventStr;
+    }
+
     if( py::hasattr(self, methodName.c_str()) )
     {
         py::object fct = self.attr(methodName.c_str());


### PR DESCRIPTION
It is often useful to be able to see what kind of events are received by a controller.

This PR add this behavior by printing the message name and parameters in the console when the 'printLog'  data is checked.
```console
[INFO]    [MyController(TOTO)] onUpdateMappingEndEvent {'type': 'UpdateMappingEndEvent', 'isHandled': False}
[INFO]    [MyController(TOTO)] onAnimateBeginEvent {'type': 'AnimateBeginEvent', 'isHandled': False, 'dt': 0.01}
[INFO]    [MyController(TOTO)] onAnimateEndEvent {'type': 'AnimateEndEvent', 'isHandled': False, 'dt': 0.01}
[INFO]    [MyController(TOTO)] onUpdateMappingEndEvent {'type': 'UpdateMappingEndEvent', 'isHandled': False}