### PR TITLE
Add bindings for matrix access

### DIFF
--- a/bindings/BindingsConfig.cmake.in
+++ b/bindings/BindingsConfig.cmake.in
@@ -11,6 +11,7 @@ find_package(SofaPython3 QUIET REQUIRED COMPONENTS
     Bindings.SofaGui
     Bindings.SofaRuntime
     Bindings.SofaTypes
+    Bindings.SofaLinearSolver
     )
 if(SP3_WITH_SOFAEXPORTER)
     find_package(SofaPython3 QUIET REQUIRED COMPONENTS Bindings.SofaExporter)

--- a/bindings/Modules/Bindings.ModulesConfig.cmake.in
+++ b/bindings/Modules/Bindings.ModulesConfig.cmake.in
@@ -9,6 +9,8 @@ find_package(SofaPython3 QUIET REQUIRED COMPONENTS Plugin Bindings.Sofa)
 find_package(SofaBaseTopology QUIET REQUIRED)
 # Required by Bindings.Modules.SofaDeformable
 find_package(SofaDeformable QUIET REQUIRED)
+# Required by Bindings.Modules.SofaLinearSolver
+find_package(Sofa.Component.LinearSolver.Iterative REQUIRED)
 
 # If we are importing this config file and the target is not yet there this is indicating that
 # target is an imported one. So we include it

--- a/bindings/Modules/CMakeLists.txt
+++ b/bindings/Modules/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(Bindings.Modules)
 
-set(MODULEBINDINGS_MODULE_LIST SofaBaseTopology SofaDeformable)
+set(MODULEBINDINGS_MODULE_LIST SofaBaseTopology SofaDeformable SofaLinearSolver)
 
 find_package(Sofa.GL QUIET)
 if(Sofa.GL_FOUND)

--- a/bindings/Modules/src/SofaPython3/SofaLinearSolver/Binding_LinearSolver.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSolver/Binding_LinearSolver.cpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaPython3/SofaLinearSolver/Binding_LinearSolver.h>
+#include <SofaPython3/SofaLinearSolver/Binding_LinearSolver_doc.h>
+#include <pybind11/pybind11.h>
+
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/PythonFactory.h>
+
+#include <sofa/component/linearsolver/iterative/MatrixLinearSolver.h>
+#include <pybind11/eigen.h>
+
+namespace py { using namespace pybind11; }
+
+namespace sofapython3 {
+
+using CRS = sofa::linearalgebra::CompressedRowSparseMatrix<SReal>;
+using CRSLinearSolver = sofa::component::linearsolver::MatrixLinearSolver<CRS, sofa::linearalgebra::FullVector<SReal> >;
+using EigenSparseMatrix = Eigen::SparseMatrix<SReal, Eigen::RowMajor>;
+using EigenMatrixMap = Eigen::Map<Eigen::SparseMatrix<SReal, Eigen::RowMajor> >;
+using Vector = Eigen::Matrix<SReal,Eigen::Dynamic, 1>;
+using EigenVectorMap = Eigen::Map<Vector>;
+
+void moduleAddLinearSolver(py::module &m)
+{
+    const std::string type_name = CRSLinearSolver::GetClass()->className;
+
+    py::class_<CRSLinearSolver,
+               sofa::core::objectmodel::BaseObject,
+               sofapython3::py_shared_ptr<CRSLinearSolver> > c(m, type_name.c_str(), sofapython3::doc::linearsolver::linearSolverClass);
+
+    c.def("A", [](CRSLinearSolver& self) -> EigenSparseMatrix
+    {
+        if (CRS* matrix = self.getSystemMatrix())
+        {
+            return EigenMatrixMap(matrix->rows(), matrix->cols(), matrix->getColsValue().size(),
+                    (EigenMatrixMap::StorageIndex*)matrix->rowBegin.data(), (EigenMatrixMap::StorageIndex*)matrix->colsIndex.data(), matrix->colsValue.data());
+        }
+        return {};
+    }, sofapython3::doc::linearsolver::linearSolver_A);
+
+    c.def("b", [](CRSLinearSolver& self) -> Vector
+    {
+        if (auto* vector = self.getSystemRHVector())
+        {
+            return EigenVectorMap(vector->ptr(), vector->size());
+        }
+        return {};
+    }, sofapython3::doc::linearsolver::linearSolver_b);
+
+    c.def("x", [](CRSLinearSolver& self) -> Vector
+    {
+        if (auto* vector = self.getSystemLHVector())
+        {
+            return EigenVectorMap(vector->ptr(), vector->size());
+        }
+        return {};
+    }, sofapython3::doc::linearsolver::linearSolver_x);
+
+
+    /// register the binding in the downcasting subsystem
+    PythonFactory::registerType<CRSLinearSolver>([](sofa::core::objectmodel::Base* object)
+    {
+        return py::cast(dynamic_cast<CRSLinearSolver*>(object));
+    });
+}
+
+}

--- a/bindings/Modules/src/SofaPython3/SofaLinearSolver/Binding_LinearSolver.h
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSolver/Binding_LinearSolver.h
@@ -1,0 +1,31 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3
+{
+
+void moduleAddLinearSolver(pybind11::module &m);
+
+} /// namespace sofapython3
+

--- a/bindings/Modules/src/SofaPython3/SofaLinearSolver/Binding_LinearSolver_doc.h
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSolver/Binding_LinearSolver_doc.h
@@ -1,0 +1,66 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::linearsolver {
+
+static auto linearSolverClass =
+R"(
+Linear solver. Supports only scalar CompressedRowSparseMatrix.
+
+example:
+------------
+
+linear_solver = root.addObject('SparseLDLSolver', template='CompressedRowSparseMatrixd') # supported
+linear_solver = root.addObject('SparseLDLSolver', template='CompressedRowSparseMatrixMat3x3d') # not supported
+)";
+
+static auto linearSolver_A =
+R"(
+Returns the global system matrix as a scipy sparse matrix
+
+example:
+------------
+linear_solver = root.addObject('SparseLDLSolver', template='CompressedRowSparseMatrixd')
+matrix = linear_solver.A()
+)";
+
+static auto linearSolver_b =
+R"(
+Returns the global system right hand side as a numpy array
+
+example:
+------------
+linear_solver = root.addObject('SparseLDLSolver', template='CompressedRowSparseMatrixd')
+matrix = linear_solver.b()
+)";
+
+static auto linearSolver_x =
+R"(
+Returns the global system solution vector as a numpy array
+
+example:
+------------
+linear_solver = root.addObject('SparseLDLSolver', template='CompressedRowSparseMatrixd')
+matrix = linear_solver.x()
+)";
+
+} // namespace sofapython3::doc::baseCamera

--- a/bindings/Modules/src/SofaPython3/SofaLinearSolver/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSolver/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(Bindings.Modules.SofaLinearSolver)
+
+set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinearSolver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinearSolver_doc.h
+)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinearSolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Module_SofaLinearSolver.cpp
+)
+
+if (NOT TARGET SofaPython3::Plugin)
+    find_package(SofaPython3 REQUIRED COMPONENTS Plugin Bindings.Sofa)
+endif()
+
+find_package(Sofa.Component.LinearSolver.Iterative REQUIRED)
+
+SP3_add_python_module(
+    TARGET       ${PROJECT_NAME}
+    PACKAGE      Bindings.Modules
+    MODULE       SofaLinearSolver
+    DESTINATION  Sofa
+    SOURCES      ${SOURCE_FILES}
+    HEADERS      ${HEADER_FILES}
+    DEPENDS      Sofa.Component.LinearSolver.Iterative SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+)

--- a/bindings/Modules/src/SofaPython3/SofaLinearSolver/Module_SofaLinearSolver.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSolver/Module_SofaLinearSolver.cpp
@@ -1,0 +1,33 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <SofaPython3/SofaLinearSolver/Binding_LinearSolver.h>
+
+namespace sofapython3
+{
+
+PYBIND11_MODULE(SofaLinearSolver, m)
+{
+    moduleAddLinearSolver(m);
+}
+
+}  // namespace sofapython3
+

--- a/examples/access_matrix.py
+++ b/examples/access_matrix.py
@@ -1,0 +1,65 @@
+# Required import for python
+import Sofa
+import SofaRuntime
+from Sofa import SofaLinearSolver
+from scipy import sparse
+
+# Function called when the scene graph is being created
+def createScene(root):
+
+    root.addObject('VisualStyle', displayFlags="showBehaviorModels showForceFields")
+
+    root.addObject('DefaultAnimationLoop')
+    root.addObject('DefaultVisualManagerLoop')
+
+    root.addObject('EulerImplicitSolver', rayleighStiffness="0.1", rayleighMass="0.1")
+    linear_solver = root.addObject('SparseLDLSolver', applyPermutation="false", template="CompressedRowSparseMatrixd")
+
+    root.addObject('MechanicalObject', name="DoFs")
+    root.addObject('UniformMass', name="mass", totalMass="320")
+    root.addObject('RegularGridTopology', name="grid", nx="4", ny="4", nz="20", xmin="-9", xmax="-6", ymin="0", ymax="3", zmin="0", zmax="19")
+    root.addObject('BoxROI', name="box", box="-10 -1 -0.0001  -5 4 0.0001")
+    root.addObject('FixedConstraint', indices="@box.indices")
+    root.addObject('HexahedronFEMForceField', name="FEM", youngModulus="4000", poissonRatio="0.3", method="large")
+
+    root.addObject(MatrixAccessController('MatrixAccessor', name='matrixAccessor', linear_solver=linear_solver))
+
+    return root
+
+
+class MatrixAccessController(Sofa.Core.Controller):
+
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.Controller.__init__(self, *args, **kwargs)
+        self.linear_solver = kwargs.get("linear_solver")
+
+    def onAnimateEndEvent(self, event):
+        system_matrix = self.linear_solver.A()
+        rhs = self.linear_solver.b()
+        solution = self.linear_solver.x()
+
+        print('====================================')
+        print('Global system matrix')
+        print('====================================')
+        print('dtype: ' + str(system_matrix.dtype))
+        print('shape: ' + str(system_matrix.shape))
+        print('ndim: ' + str(system_matrix.ndim))
+        print('nnz: ' + str(system_matrix.nnz))
+
+        print('====================================')
+        print('System right hand side')
+        print('====================================')
+        print('dtype: ' + str(rhs.dtype))
+        print('shape: ' + str(rhs.shape))
+        print('ndim: ' + str(rhs.ndim))
+
+        print('====================================')
+        print('System solution')
+        print('====================================')
+        print('dtype: ' + str(solution.dtype))
+        print('shape: ' + str(solution.shape))
+        print('ndim: ' + str(solution.ndim))
+
+        pass
+


### PR DESCRIPTION
Python bindings for accessing `A`, `x` and `b` from a linear solver solving the system `Ax=b`.

An example is introduced.
In the example, the output after a time step:

```
====================================
Global system matrix
====================================
dtype: float64
shape: (960, 960)
ndim: 2
nnz: 52200
====================================
System right hand side
====================================
dtype: float64
shape: (960,)
ndim: 1
====================================
System solution
====================================
dtype: float64
shape: (960,)
ndim: 1
```

Note: I took the same binding names than in [Caribou](https://github.com/jnbrunet/caribou/blob/master/src/SofaCaribou/Python/Solver/LDLTSolver.h)