### PR TITLE
Bindings to access matrices from force fields and masses

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -52,6 +52,7 @@ namespace sofapython3
     using sofa::defaulttype::Vec3dTypes;
     using sofa::defaulttype::Vec2dTypes;
     using sofa::defaulttype::Vec1dTypes;
+    using sofa::defaulttype::Vec6dTypes;
     using sofa::defaulttype::Rigid3dTypes;
     using sofa::defaulttype::Rigid2dTypes;
 
@@ -232,6 +233,9 @@ namespace sofapython3
             }
             matrix.compress();
 
+            if (matrix.getColsValue().empty() || matrix.rowBegin.empty() || matrix.colsIndex.empty())
+                return {};
+
             return EigenMatrixMap(matrix.rows(), matrix.cols(), matrix.getColsValue().size(),
                                 (typename EigenMatrixMap::StorageIndex*)matrix.rowBegin.data(),
                                 (typename EigenMatrixMap::StorageIndex*)matrix.colsIndex.data(),
@@ -249,6 +253,7 @@ void moduleAddForceField(py::module &m) {
     declare_forcefield<Vec3dTypes>(m);
     declare_forcefield<Vec2dTypes>(m);
     declare_forcefield<Vec1dTypes>(m);
+    declare_forcefield<Vec6dTypes>(m);
     declare_forcefield<Rigid3dTypes>(m);
     declare_forcefield<Rigid2dTypes>(m);
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
@@ -28,7 +28,7 @@
 namespace sofapython3 {
 
 template<class TDOFType>
-class ForceField_Trampoline  : public sofa::core::behavior::ForceField<TDOFType> {
+class ForceField_Trampoline : public sofa::core::behavior::ForceField<TDOFType> {
 public:
     SOFA_CLASS(ForceField_Trampoline, SOFA_TEMPLATE(sofa::core::behavior::ForceField, TDOFType));
     using sofa::core::behavior::ForceField<TDOFType>::mstate;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField_doc.h
@@ -25,4 +25,20 @@ namespace sofapython3::doc::forceField
 static auto forceFieldClass = R"(
                          An overridable class to create your own customized force field.
                          )";
+
+static constexpr const char* assembleKMatrix = R"(
+Assemble the stiffness matrix of a force field.
+
+Note that this function is not free. It assembles the stiffness matrix whether or not it has been assembled previously
+to add it into the global system matrix. Besides, the function does not prevent side effects of a second matrix assembly
+in a single time step.
+
+Typical usage example:
+FEM = root.addObject('HexahedronFEMForceField', name="FEM", youngModulus="4000", poissonRatio="0.3", method="large")
+...
+stiffness_matrix = self.force_field.assembleKMatrix()
+
+Returns:
+    A scipy.sparse.csr_matrix object representing the stiffness matrix of the force field
+)";
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass.cpp
@@ -1,0 +1,97 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_Mass.h>
+#include <SofaPython3/Sofa/Core/Binding_Mass_doc.h>
+#include <SofaPython3/PythonFactory.h>
+
+#include <sofa/core/behavior/MechanicalState.h>
+#include <sofa/core/behavior/Mass.h>
+#include <sofa/core/MechanicalParams.h>
+#include <sofa/core/behavior/DefaultMultiMatrixAccessor.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+
+#include <pybind11/eigen.h>
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+namespace sofapython3
+{
+
+using sofa::core::behavior::Mass;
+
+template<class TDOFType>
+void declare_mass(py::module &m) {
+    const std::string pyclass_name = std::string("Mass") + TDOFType::Name();
+    py::class_<Mass<TDOFType>, sofa::core::behavior::ForceField<TDOFType>, py_shared_ptr<Mass<TDOFType>>> f(m, pyclass_name.c_str(), sofapython3::doc::mass::massClass);
+
+    using Real = typename TDOFType::Real;
+    using EigenSparseMatrix = Eigen::SparseMatrix<typename TDOFType::Real, Eigen::RowMajor>;
+    using EigenMatrixMap = Eigen::Map<EigenSparseMatrix>;
+
+    f.def("assembleMMatrix", [](Mass<TDOFType>& self) -> EigenSparseMatrix
+    {
+        sofa::linearalgebra::CompressedRowSparseMatrix<Real> matrix;
+
+        if (const auto* mstate = self.getMState())
+        {
+            const auto matrixSize = static_cast<sofa::linearalgebra::BaseMatrix::Index>(mstate->getMatrixSize());
+            matrix.resize(matrixSize, matrixSize);
+
+            sofa::core::behavior::DefaultMultiMatrixAccessor accessor;
+            accessor.addMechanicalState(mstate);
+            accessor.setGlobalMatrix(&matrix);
+
+            auto mparams = *sofa::core::MechanicalParams::defaultInstance();
+            mparams.setKFactor(0.).setMFactor(1.).setBFactor(0.);
+
+            self.addMToMatrix(&mparams, &accessor);
+        }
+        matrix.compress();
+
+        if (matrix.getColsValue().empty() || matrix.rowBegin.empty() || matrix.colsIndex.empty())
+            return {};
+
+        return EigenMatrixMap(matrix.rows(), matrix.cols(), matrix.getColsValue().size(),
+                            (typename EigenMatrixMap::StorageIndex*)matrix.rowBegin.data(),
+                            (typename EigenMatrixMap::StorageIndex*)matrix.colsIndex.data(),
+                            matrix.colsValue.data());
+    }, sofapython3::doc::mass::assembleMMatrix);
+
+    PythonFactory::registerType<Mass<TDOFType>>([](sofa::core::objectmodel::Base* object)
+    {
+        return py::cast(dynamic_cast<Mass<TDOFType>*>(object));
+    });
+}
+
+
+void moduleAddMass(py::module &m) {
+    declare_mass<sofa::defaulttype::Vec3dTypes>(m);
+    declare_mass<sofa::defaulttype::Vec2dTypes>(m);
+    declare_mass<sofa::defaulttype::Vec1dTypes>(m);
+    declare_mass<sofa::defaulttype::Vec6dTypes>(m);
+    declare_mass<sofa::defaulttype::Rigid3dTypes>(m);
+    declare_mass<sofa::defaulttype::Rigid2dTypes>(m);
+}
+
+}  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddMass(pybind11::module &m);
+
+} /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass_doc.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::mass
+{
+static auto massClass = R"(
+                         Mass is an API dedicated to the control of a mass in SOFA.
+                         )";
+
+static constexpr const char* assembleMMatrix = R"(
+Assemble the mass matrix of a mass.
+
+Note that this function is not free. It assembles the mass matrix whether or not it has been assembled previously
+to add it into the global system matrix. Besides, the function does not prevent side effects of a second matrix assembly
+in a single time step.
+
+Typical usage example:
+mass = root.addObject('MeshMatrixMass', name="mass", totalMass="320")
+...
+mass_matrix = mass.assembleMMatrix()
+
+Returns:
+    A scipy.sparse.csr_matrix object representing the mass matrix of the mass
+)";
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -19,6 +19,8 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Mass.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Mass_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node.h
@@ -58,6 +60,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataLink.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataVectorString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Mass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_NodeIterator.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -29,6 +29,7 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Binding_BaseData.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseCamera.h>
 #include <SofaPython3/Sofa/Core/Binding_ForceField.h>
+#include <SofaPython3/Sofa/Core/Binding_Mass.h>
 #include <SofaPython3/Sofa/Core/Binding_ContactListener.h>
 #include <SofaPython3/Sofa/Core/Binding_Context.h>
 #include <SofaPython3/Sofa/Core/Binding_Controller.h>
@@ -131,6 +132,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddController(core);
     moduleAddDataEngine(core);
     moduleAddForceField(core);
+    moduleAddMass(core);
     moduleAddObjectFactory(core);
     moduleAddNode(core);
     moduleAddNodeIterator(core);

--- a/examples/access_mass_matrix.py
+++ b/examples/access_mass_matrix.py
@@ -22,13 +22,13 @@ def createScene(root):
     root.addObject('SparseLDLSolver', applyPermutation="false", template="CompressedRowSparseMatrixd")
 
     root.addObject('MechanicalObject', name="DoFs")
-    root.addObject('MeshMatrixMass', name="mass", totalMass="320")
+    mass = root.addObject('MeshMatrixMass', name="mass", totalMass="320")
     root.addObject('RegularGridTopology', name="grid", nx="4", ny="4", nz="20", xmin="-9", xmax="-6", ymin="0", ymax="3", zmin="0", zmax="19")
     root.addObject('BoxROI', name="box", box="-10 -1 -0.0001  -5 4 0.0001")
     root.addObject('FixedConstraint', indices="@box.indices")
-    FEM = root.addObject('HexahedronFEMForceField', name="FEM", youngModulus="4000", poissonRatio="0.3", method="large")
+    root.addObject('HexahedronFEMForceField', name="FEM", youngModulus="4000", poissonRatio="0.3", method="large")
 
-    root.addObject(MatrixAccessController('MatrixAccessor', name='matrixAccessor', force_field=FEM))
+    root.addObject(MatrixAccessController('MatrixAccessor', name='matrixAccessor', mass=mass))
 
     return root
 
@@ -38,23 +38,23 @@ class MatrixAccessController(Sofa.Core.Controller):
 
     def __init__(self, *args, **kwargs):
         Sofa.Core.Controller.__init__(self, *args, **kwargs)
-        self.force_field = kwargs.get("force_field")
+        self.mass = kwargs.get("mass")
 
     def onAnimateEndEvent(self, event):
-        stiffness_matrix = self.force_field.assembleKMatrix()
+        mass_matrix = self.mass.assembleMMatrix()
 
         print('====================================')
         print('Stiffness matrix')
         print('====================================')
-        print('dtype: ' + str(stiffness_matrix.dtype))
-        print('shape: ' + str(stiffness_matrix.shape))
-        print('ndim: ' + str(stiffness_matrix.ndim))
-        print('nnz: ' + str(stiffness_matrix.nnz))
-        print('norm: ' + str(sparse.linalg.norm(stiffness_matrix)))
+        print('dtype: ' + str(mass_matrix.dtype))
+        print('shape: ' + str(mass_matrix.shape))
+        print('ndim: ' + str(mass_matrix.ndim))
+        print('nnz: ' + str(mass_matrix.nnz))
+        print('norm: ' + str(sparse.linalg.norm(mass_matrix)))
 
         if exportCSV:
-            np.savetxt('stiffness.csv', stiffness_matrix.toarray(), delimiter=',')
+            np.savetxt('mass.csv', mass_matrix.toarray(), delimiter=',')
         if showImage:
-            plt.imshow(stiffness_matrix.toarray(), interpolation='nearest', cmap='gist_gray')
+            plt.imshow(mass_matrix.toarray(), interpolation='nearest', cmap='gist_gray')
             plt.show()
 

--- a/examples/access_stiffness_matrix.py
+++ b/examples/access_stiffness_matrix.py
@@ -1,0 +1,49 @@
+# Required import for python
+import Sofa
+import SofaRuntime
+from Sofa import SofaLinearSolver
+from scipy import sparse
+from scipy import linalg
+
+# Function called when the scene graph is being created
+def createScene(root):
+
+    root.addObject('VisualStyle', displayFlags="showBehaviorModels showForceFields")
+
+    root.addObject('DefaultAnimationLoop')
+    root.addObject('DefaultVisualManagerLoop')
+
+    root.addObject('EulerImplicitSolver', rayleighStiffness="0.1", rayleighMass="0.1")
+    root.addObject('SparseLDLSolver', applyPermutation="false", template="CompressedRowSparseMatrixd")
+
+    root.addObject('MechanicalObject', name="DoFs")
+    root.addObject('UniformMass', name="mass", totalMass="320")
+    root.addObject('RegularGridTopology', name="grid", nx="4", ny="4", nz="20", xmin="-9", xmax="-6", ymin="0", ymax="3", zmin="0", zmax="19")
+    root.addObject('BoxROI', name="box", box="-10 -1 -0.0001  -5 4 0.0001")
+    root.addObject('FixedConstraint', indices="@box.indices")
+    FEM = root.addObject('HexahedronFEMForceField', name="FEM", youngModulus="4000", poissonRatio="0.3", method="large")
+
+    root.addObject(MatrixAccessController('MatrixAccessor', name='matrixAccessor', force_field=FEM))
+
+    return root
+
+
+class MatrixAccessController(Sofa.Core.Controller):
+
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.Controller.__init__(self, *args, **kwargs)
+        self.force_field = kwargs.get("force_field")
+
+    def onAnimateEndEvent(self, event):
+        stiffness_matrix = self.force_field.assembleKMatrix()
+
+        print('====================================')
+        print('Stiffness matrix')
+        print('====================================')
+        print('dtype: ' + str(stiffness_matrix.dtype))
+        print('shape: ' + str(stiffness_matrix.shape))
+        print('ndim: ' + str(stiffness_matrix.ndim))
+        print('nnz: ' + str(stiffness_matrix.nnz))
+        print('norm: ' + str(sparse.linalg.norm(stiffness_matrix)))
+


### PR DESCRIPTION
Functions bound to force fields and masses can assemble a new matrix from scratch. Examples are provided.

Example of usage:
```python
force_field.assembleKMatrix()
mass.assembleMMatrix()
```

![image](https://user-images.githubusercontent.com/10572752/169507323-ae79d870-e6c5-4175-aaff-d1cc7f643fc5.png)
