### PR TITLE
[SofaPython3] Add a LinkPath object in both the binding and plugin.

### DIFF
--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADER_FILES
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/DataCache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/DataHelper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/LinkPath.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonFactory.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Prefab.h
 )
@@ -19,6 +20,7 @@ set(SOURCE_FILES
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/DataCache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/DataHelper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/LinkPath.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonFactory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Prefab.cpp
 )

--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -25,8 +25,10 @@
 #include <sofa/simulation/Node.h>
 
 #include <SofaPython3/DataHelper.h>
+#include <SofaPython3/LinkPath.h>
 #include <SofaPython3/DataCache.h>
 #include <SofaPython3/PythonFactory.h>
+
 
 using sofa::core::objectmodel::BaseLink;
 
@@ -60,6 +62,12 @@ std::string toSofaParsableString(const py::handle& p)
     {
         py::object o = p.attr("tolist")();
         return toSofaParsableString(o);
+    }
+
+    // if the object is a link path we set it.
+    if(py::isinstance<sofapython3::LinkPath>(p))
+    {
+        return py::str(p);
     }
 
     return py::repr(p);
@@ -463,7 +471,7 @@ BaseData* deriveTypeFromParent(sofa::core::objectmodel::BaseContext* ctx, const 
 bool isProtectedKeyword(const std::string& name)
 {
     if (name == "children" || name == "objects" || name == "parents" ||
-            name == "data" || name == "links")
+            name == "data" || name == "links" || name == "linkpath")
     {
         return true;
     }

--- a/Plugin/src/SofaPython3/LinkPath.cpp
+++ b/Plugin/src/SofaPython3/LinkPath.cpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <SofaPython3/LinkPath.h>
+
+namespace sofapython3
+{
+
+LinkPath::LinkPath(sofa::core::sptr<sofa::core::objectmodel::Base> target)
+{
+    targetBase = target;
+    targetData = nullptr;
+}
+
+LinkPath::LinkPath(sofa::core::objectmodel::BaseData* target)
+{
+    if(target->getOwner())
+    {
+        targetBase = target->getOwner();
+    }
+    targetData = target;
+}
+
+bool LinkPath::isPointingToData() const
+{
+    return targetData != nullptr;
+}
+
+}/// namespace sofapython3

--- a/Plugin/src/SofaPython3/LinkPath.cpp
+++ b/Plugin/src/SofaPython3/LinkPath.cpp
@@ -31,10 +31,7 @@ LinkPath::LinkPath(sofa::core::sptr<sofa::core::objectmodel::Base> target)
 
 LinkPath::LinkPath(sofa::core::objectmodel::BaseData* target)
 {
-    if(target->getOwner())
-    {
-        targetBase = target->getOwner();
-    }
+    targetBase = target->getOwner();
     targetData = target;
 }
 

--- a/Plugin/src/SofaPython3/LinkPath.h
+++ b/Plugin/src/SofaPython3/LinkPath.h
@@ -1,0 +1,46 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/objectmodel/BaseData.h>
+
+namespace sofapython3
+{
+
+/// A placeholder class storing a link to a data or a base
+///
+/// LinkPath can be used to indicate that a link is needed to be made in place of a string
+/// like "@/usr/myobj.position" or "@/usr/myobj"
+///
+class LinkPath
+{
+public:
+    sofa::core::sptr<sofa::core::objectmodel::Base> targetBase;
+    sofa::core::objectmodel::BaseData* targetData;
+
+    LinkPath(sofa::core::sptr<sofa::core::objectmodel::Base>);
+    LinkPath(sofa::core::objectmodel::BaseData*);
+
+    bool isPointingToData() const;
+};
+
+} /// sofapython3

--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -52,6 +52,7 @@ using sofa::core::objectmodel::ScriptEvent;
 using sofa::core::objectmodel::Event;
 
 #include <SofaPython3/PythonEnvironment.h>
+#include <SofaPython3/LinkPath.h>
 
 #include <sofa/core/topology/Topology.h>
 
@@ -293,6 +294,12 @@ void copyFromListOf<std::string>(BaseData& d, const AbstractTypeInfo& nfo, const
 
 void PythonFactory::fromPython(BaseData* d, const py::object& o)
 {
+    if(py::isinstance<sofapython3::LinkPath>(o))
+    {
+        d->setParent(py::cast<LinkPath&>(o).targetData);
+        return;
+    }
+
     const AbstractTypeInfo& nfo{ *(d->getValueTypeInfo()) };
 
     // Is this data field a container ?

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
@@ -48,6 +48,7 @@ public:
     /// Set the data field value from the array.
     static void SetDataFromArray(sofa::core::objectmodel::BaseData* data, const pybind11::array& value);
     static bool SetData(sofa::core::objectmodel::BaseData* data, pybind11::object value);
+    static bool SetLink(sofa::core::objectmodel::BaseLink* link, pybind11::object value);
     static pybind11::object setDataValues(sofa::core::objectmodel::Base& self, pybind11::kwargs kwargs);
 
     static pybind11::list getDataFields(sofa::core::objectmodel::Base& self);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
@@ -29,6 +29,7 @@
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseData.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseData_doc.h>
+#include <SofaPython3/Sofa/Core/Binding_LinkPath.h>
 #include <SofaPython3/Sofa/Core/Data/Binding_DataContainer.h>
 #include <SofaPython3/DataHelper.h>
 #include <SofaPython3/PythonFactory.h>
@@ -139,7 +140,7 @@ py::object __getattr__(py::object self, const std::string& s)
         return PythonFactory::valueToPython_ro(py::cast<BaseData*>(self));
 
     if(s == "linkpath")
-        return py::cast((py::cast<BaseData*>(self))->getLinkPath());
+        return py::cast(sofapython3::LinkPath(py::cast<BaseData*>(self)));
 
     /// BaseData does not support dynamic attributes, if you think this is an important feature
     /// please request for its integration.
@@ -151,9 +152,16 @@ void setParent(BaseData* self, BaseData* parent)
     self->setParent(parent);
 }
 
-void setParentFromLinkPath(BaseData* self, const std::string& parent)
+void setParentFromLinkPathStr(BaseData* self, const std::string& parent)
 {
     self->setParent(parent);
+}
+
+void setParentFromLinkPath(BaseData* self, const LinkPath& parent)
+{
+    if(!parent.isPointingToData())
+        throw std::runtime_error("The provided linkpath is not containing a linkable data");
+    self->setParent(parent.targetData);
 }
 
 bool hasParent(BaseData *self)
@@ -205,6 +213,7 @@ void moduleAddBaseData(py::module& m)
     data.def("isPersistent", &BaseData::isPersistent, sofapython3::doc::baseData::isPersistent);
     data.def("setPersistent", &BaseData::setPersistent, sofapython3::doc::baseData::setPersistent);
     data.def("setParent", setParent, sofapython3::doc::baseData::setParent);
+    data.def("setParent", setParentFromLinkPathStr, sofapython3::doc::baseData::setParent);
     data.def("setParent", setParentFromLinkPath, sofapython3::doc::baseData::setParent);
     data.def("hasParent", hasParent, sofapython3::doc::baseData::hasParent);
     data.def("read", &BaseData::read, sofapython3::doc::baseData::read);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_LinkPath.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_LinkPath.cpp
@@ -1,0 +1,84 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <sofa/core/objectmodel/BaseLink.h>
+using sofa::core::objectmodel::BaseLink;
+
+#include <sofa/core/objectmodel/BaseObject.h>
+using  sofa::core::objectmodel::BaseObject;
+
+#include <SofaPython3/Sofa/Core/Binding_LinkPath.h>
+#include <SofaPython3/Sofa/Core/Binding_LinkPath_doc.h>
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+// To bring in the `_a` literal
+using namespace pybind11::literals;
+
+namespace sofapython3
+{
+
+LinkPath::LinkPath(sofa::core::sptr<sofa::core::objectmodel::Base> target)
+{
+    targetBase = target;
+    targetData = nullptr;
+}
+
+LinkPath::LinkPath(sofa::core::objectmodel::BaseData* target)
+{
+    // If the data is attached to
+    if(target->getOwner())
+    {
+        targetBase = target->getOwner();
+    }
+    targetData = target;
+}
+
+bool LinkPath::isPointingToData() const
+{
+    return targetData != nullptr;
+}
+
+std::string __str__(const LinkPath& entry)
+{
+    std::ostringstream s;
+    if(entry.targetData != nullptr)
+        return entry.targetData->getLinkPath();
+    else if(entry.targetBase.get() != nullptr)
+        return "@" + entry.targetBase->getPathName();
+    throw std::runtime_error("Empty LinkPath");
+}
+
+std::string __repr__(const LinkPath& entry)
+{
+    std::ostringstream s;
+    s << "LinkPath(\"" << __str__(entry) << "\")";
+    return s.str();
+}
+
+void moduleAddLinkPath(py::module& m)
+{
+    py::class_<LinkPath> link(m, "LinkPath", sofapython3::doc::linkpath::linkpath);
+    link.def("__str__", &__str__);
+    link.def("__repr__", &__repr__);
+}
+
+}/// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_LinkPath.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_LinkPath.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <sofa/core/objectmodel/Base.h>
+#include <sofa/core/objectmodel/BaseData.h>
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+/// A placeholder class storing a link to a data or a base
+class LinkPath
+{
+public:
+    sofa::core::sptr<sofa::core::objectmodel::Base> targetBase;
+    sofa::core::objectmodel::BaseData* targetData;
+
+    LinkPath(sofa::core::sptr<sofa::core::objectmodel::Base>);
+    LinkPath(sofa::core::objectmodel::BaseData*);
+
+    bool isPointingToData() const;
+};
+
+void moduleAddLinkPath(pybind11::module& m);
+
+} /// sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_LinkPath_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_LinkPath_doc.h
@@ -1,0 +1,35 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::linkpath
+{
+static auto linkpath =
+        R"(
+        Hold a linkpath to an object or a data.
+        Example of use:
+            node.addObject("MechanicalObject", name="o")
+            node.addObject(position=node.o.position.linkpath)
+
+            str(node.o.linkpath) # prints LinkPath("@/o.position")
+            repr(node.o.linkpath) # prints "@/o.position"
+        )";
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -193,17 +193,17 @@ void setFieldsFromPythonValues(Base* self, const py::kwargs& dict)
     // For each argument of the addObject functin we check if this is a
     // and argument we can do a raw conversion from.
     // currently, only the LinkPath object is supported.
-    for(auto kv : dict)
+    for(auto [key, value] : dict)
     {
-        if(py::isinstance<LinkPath>(kv.second))
+        if(py::isinstance<LinkPath>(value))
         {
-            auto* data = self->findData(py::str(kv.first));
+            auto* data = self->findData(py::str(key));
             if(data)
-                BindingBase::SetData(data, py::cast<py::object>(kv.second));
+                BindingBase::SetData(data, py::cast<py::object>(value));
 
-            auto* link = self->findLink(py::str(kv.first));
+            auto* link = self->findLink(py::str(key));
             if(link)
-                BindingBase::SetLink(link, py::cast<py::object>(kv.second));
+                BindingBase::SetLink(link, py::cast<py::object>(value));
         }
     }
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -38,6 +38,9 @@ using sofa::helper::logging::Message;
 #include <SofaSimulationGraph/DAGNode.h>
 using sofa::core::ExecParams;
 
+#include <SofaPython3/LinkPath.h>
+using sofapython3::LinkPath;
+
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
 #include <SofaPython3/DataHelper.h>
@@ -185,6 +188,26 @@ py::object getObject(Node &n, const std::string &name, const py::kwargs& kwargs)
     return py::none();
 }
 
+void setFieldsFromPythonValues(Base* self, const py::kwargs& dict)
+{
+    // For each argument of the addObject functin we check if this is a
+    // and argument we can do a raw conversion from.
+    // currently, only the LinkPath object is supported.
+    for(auto kv : dict)
+    {
+        if(py::isinstance<LinkPath>(kv.second))
+        {
+            auto* data = self->findData(py::str(kv.first));
+            if(data)
+                BindingBase::SetData(data, py::cast<py::object>(kv.second));
+
+            auto* link = self->findLink(py::str(kv.first));
+            if(link)
+                BindingBase::SetLink(link, py::cast<py::object>(kv.second));
+        }
+    }
+}
+
 /// Implement the addObject function.
 py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs& kwargs)
 {
@@ -217,6 +240,12 @@ py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs
         const auto resolvedName = self->getNameHelper().resolveName(object->getClassName(), name, sofa::core::ComponentNameHelper::Convention::python);
         object->setName(resolvedName);
     }
+
+    auto finfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
+    object->setInstanciationSourceFileName(finfo->filename);
+    object->setInstanciationSourceFilePos(finfo->line);
+
+    setFieldsFromPythonValues(object.get(), kwargs);
 
     checkParamUsage(desc);
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -241,10 +241,6 @@ py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs
         object->setName(resolvedName);
     }
 
-    auto finfo = PythonEnvironment::getPythonCallingPointAsFileInfo();
-    object->setInstanciationSourceFileName(finfo->filename);
-    object->setInstanciationSourceFilePos(finfo->line);
-
     setFieldsFromPythonValues(object.get(), kwargs);
 
     checkParamUsage(desc);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -190,9 +190,8 @@ py::object getObject(Node &n, const std::string &name, const py::kwargs& kwargs)
 
 void setFieldsFromPythonValues(Base* self, const py::kwargs& dict)
 {
-    // For each argument of the addObject functin we check if this is a
-    // and argument we can do a raw conversion from.
-    // currently, only the LinkPath object is supported.
+    // For each argument of the addObject function we check if this is an argument we can do a raw conversion from.
+    // Doing a raw conversion means that we are not converting the argument anymore into a sofa parsable string.
     for(auto [key, value] : dict)
     {
         if(py::isinstance<LinkPath>(value))

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -19,6 +19,8 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinkPath.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinkPath_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node.h
@@ -58,6 +60,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataLink.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataVectorString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ForceField.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinkPath.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_NodeIterator.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -34,6 +34,7 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Binding_Controller.h>
 #include <SofaPython3/Sofa/Core/Binding_DataEngine.h>
 #include <SofaPython3/Sofa/Core/Binding_ObjectFactory.h>
+#include <SofaPython3/Sofa/Core/Binding_LinkPath.h>
 #include <SofaPython3/Sofa/Core/Binding_Node.h>
 #include <SofaPython3/Sofa/Core/Binding_NodeIterator.h>
 #include <SofaPython3/Sofa/Core/Binding_Prefab.h>
@@ -109,6 +110,7 @@ PYBIND11_MODULE(Core, core)
                Sofa.Core.DataContainer
                Sofa.Core.DataString
                Sofa.Core.DataVectorString
+               Sofa.Core.LinkPath
                Sofa.Core.NodeIterator
                #Sofa.Core.WriteAccessor
        )doc";
@@ -132,6 +134,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddDataEngine(core);
     moduleAddForceField(core);
     moduleAddObjectFactory(core);
+    moduleAddLinkPath(core);
     moduleAddNode(core);
     moduleAddNodeIterator(core);
     moduleAddPrefab(core);

--- a/bindings/Sofa/tests/Core/Base.py
+++ b/bindings/Sofa/tests/Core/Base.py
@@ -99,7 +99,6 @@ class Test(unittest.TestCase):
         # child properly updated from parent value
         self.assertEqual("test", c1.d2.value)
 
-
     def test_addNewDataFromParent_brokenLink(self):
         root = create_scene('root')
         c1 = root.addObject("MechanicalObject", name="c1")
@@ -121,13 +120,21 @@ class Test(unittest.TestCase):
     def test_getTemplateName(self):
         root = create_scene("root")
         c = root.addObject("MechanicalObject", name="t")
-        self.assertEqual(c.getTemplateName(),"Vec3d")
+        self.assertEqual(c.getTemplateName(), "Vec3d")
 
     def test_getLinkPath(self):
         root = create_scene("root")
         obj = root.addObject("MechanicalObject", name="obj")
-        self.assertEqual(obj.getPathName(),"/obj")
-        self.assertEqual(obj.getLinkPath(),"@/obj")
+        self.assertEqual(obj.getPathName(), "/obj")
+        self.assertEqual(obj.getLinkPath(), "@/obj")
+
+    def test_linkpath(self):
+        """Accessing the linkpath property should return a LinkPath object with a correctly set 'path'"""
+        root = create_scene("root")
+        root.addChild("child")
+        root.child.addObject("MechanicalObject", name="dofs")
+        self.assertEqual(type(root.child.dofs.linkpath), Sofa.Core.LinkPath)
+        self.assertEqual(str(root.child.dofs.linkpath), "@/child/dofs")
 
     def test_addExistingDataAsParentOfNewData(self):
         # TODO(@marques-bruno)
@@ -148,4 +155,3 @@ class Test(unittest.TestCase):
         # self.assertEqual(aData.getOwner(), obj1)
         # self.assertEqual(obj2.aData.value, "pouet")
         pass
-

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -293,16 +293,35 @@ class Test(unittest.TestCase):
             numpy.testing.assert_array_equal(wa, v*4.0)
 
     def test_linkpath(self):
+        """Accessing the linkpath property should return a LinkPath object with a correct 'path'"""
         n = create_scene("rootNode")
         m = n. addObject("MechanicalObject", name="dofs")
-        self.assertEqual(m.position.linkpath, "@/dofs.position")
+        self.assertEqual(type(m.position.linkpath), Sofa.Core.LinkPath)
+        self.assertEqual(str(m.position.linkpath), "@/dofs.position")
+
+    def test_linkpath_in_add_object_compat(self):
+        """Checks that passing a link path to the addObject function is still working as it was before sofa 21.12"""
+        root = create_scene("root")
+        root.addObject("MechanicalObject", name="dofs1", position=[[1.0,2.0,3.0]])
+        root.addObject("MechanicalObject", name="dofs2", position=root.dofs1.position.linkpath)
+        self.assertEqual(str(root.dofs2.position.getParent().linkpath), "@/dofs1.position")
+
+    def test_linkpath_between_two_scenes(self):
+        """Checks that passing a link path to the addObject function is still working as it was before sofa 21.12"""
+        root1 = create_scene("root1")
+        root1.addChild("child1")
+        root2 = create_scene("root2")
+        root2.addChild("child2)
+        root1.child1.addObject("MechanicalObject", name="dofs1", position=[[1.0,2.0,3.0]])
+        root2.chdil2.addObject("MechanicalObject", name="dofs2", position=root1.child1.dofs1.position.linkpath)
+        self.assertEqual(root2.dofs2.position.getParent().name, "dofs1")
 
     def test_set_value_from_string(self):
         n = create_scene("rootNode")
-        n.gravity.value = [1.0,2.0,3.0]
-        self.assertEqual(list(n.gravity.value), [1.0,2.0,3.0])
+        n.gravity.value = [1.0, 2.0, 3.0]
+        self.assertEqual(list(n.gravity.value), [1.0, 2.0, 3.0])
         n.gravity.value = "4.0 5.0 6.0"
-        self.assertEqual(list(n.gravity.value), [4.0,5.0,6.0])
+        self.assertEqual(list(n.gravity.value), [4.0, 5.0, 6.0])
 
     def test_DataString(self):
         n = create_scene("rootNode")


### PR DESCRIPTION
This PR is following the discussion in #197 

The existing syntax to make links in SofaPython3 is the following one:
```python
node.addObject("MeshObjLoader", name="loader")
node.addObject("MechanicalObject", position=node.loader.position.getLinkPath())
```

In addition to be very verbose the getLinkPath() is returning a string (eg: "@/node/loader.position").
Representing linkpath with string has the drawback of forcing the two objects to be part of the same simulation graph which is not always the case.

Example of code that does not work as expected:
```python
def MyPrefab(target):
	node = Sofa.Core.Node("MyPrefab")
	node.addObject("MeshObjLoader", name="loader")
	node2.addObject("MechanicalObject", position=target)
	return node

def createScene(root):
	root.addObject("MeshObjLoader", name="loader")
	root.addChild( MyPrefab(loader.position.getLinkPath()) )
```

It does not work because string returned by getLinkPath() is a path query into the scene-graph to locate the object or the data
field to attach not into the one of the graph the destination object is. 

To solve this issue this PR introduce a LinkPath object which is dedicated to point to a sofa object.
This LinkPath object is exposed in python and can be used to make parenting between objects and data without the need of graph to path then path to graph conversion (so it is also much faster.. but we don't really care here right ?).

For consistency with the "value" in data field the PR expose the LinkPath with a dedicated "linkpath" attribute.
So the code is now the following:
```python
root.addObject("MeshObjLoader", name="loader")
root.addObject("MechanicalObject", name="p1", position=root.loader.position.value)      # Copy the value
root.addObject("MechanicalObject", name="p2", position=root.loader.position.linkpath)   # Make a link between data without the need for string based query

root.addObject("Mapping", name="loader", input=p1.linkpath)
```

