### PR TITLE
[Plugin] Fix compilation for msvc and python 3.10

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -221,9 +221,9 @@ void copyScalar(BaseData* a, const AbstractTypeInfo& nfo, pybind11::array_t<T, p
     void* ptr = a->beginEditVoidPtr();
 
     auto r = src.unchecked();
-    for (auto i = 0; i < r.shape(0); i++)
+    for (pybind11::ssize_t i = 0; i < r.shape(0); i++)
     {
-        for (auto j = 0; j < r.shape(1); j++)
+        for (pybind11::ssize_t j = 0; j < r.shape(1); j++)
         {
             nfo.setScalarValue( ptr, i*r.shape(1)+j, r(i,j) );
         }

--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -221,9 +221,9 @@ void copyScalar(BaseData* a, const AbstractTypeInfo& nfo, pybind11::array_t<T, p
     void* ptr = a->beginEditVoidPtr();
 
     auto r = src.unchecked();
-    for (ssize_t i = 0; i < r.shape(0); i++)
+    for (auto i = 0; i < r.shape(0); i++)
     {
-        for (ssize_t j = 0; j < r.shape(1); j++)
+        for (auto j = 0; j < r.shape(1); j++)
         {
             nfo.setScalarValue( ptr, i*r.shape(1)+j, r(i,j) );
         }


### PR DESCRIPTION
While doing https://github.com/sofa-framework/sofa/pull/3031 , I stumbled on a type error.

It seems that python3 <=3.9 was defining ssize_t for MSVC, but not on python3.10 anymore (my guess after few searches).
And obviously, I was on python3.10  🌝 
Hence thats why it is compiling on the CI but not on my system :lucky:
