### PR TITLE
Change the Prefab's parameters and implemention to make it usage clear. 

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -273,9 +273,9 @@ class scoped_read_access
 {
 public:
     BaseData* data{nullptr};
-    void* ptr{nullptr};
-    scoped_read_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
-    ~scoped_read_access(){ data->endEditVoidPtr(); }
+    const void* ptr{nullptr};
+    scoped_read_access(BaseData* data_) : data(data_){ ptr = data->getValueVoidPtr(); }
+    ~scoped_read_access(){ }
 };
 
 class scoped_writeonly_access

--- a/Plugin/src/SofaPython3/Prefab.h
+++ b/Plugin/src/SofaPython3/Prefab.h
@@ -55,9 +55,10 @@ class SOFAPYTHON3_API Prefab : public BasePrefab
 {
 public:
     SOFA_CLASS(Prefab, BasePrefab);
-    void init();
+    void initPrefab();
     void reinit();
-    virtual void doReInit() ;
+    virtual void init();
+    virtual void onParameterChanged();
 
     void addPrefabParameter(const std::string& name, const std::string& help, const std::string& type, pybind11::object defaultValue = pybind11::none());
     void setSourceTracking(const std::string& filename);

--- a/bindings/Sofa/package/prefab.py
+++ b/bindings/Sofa/package/prefab.py
@@ -1,34 +1,50 @@
 import Sofa.Core
 import inspect
 
+
 class Prefab(Sofa.Core.RawPrefab):
     """
-    The Prefab object is a Base class to create custom Prefab components for SOFA, implemented in python.
-    A Prefab can have parameters defined in the "properties" list (datafields under the group "Prefab's Properties"), that trigger its doReInit() function when modified. Parameters must be in a list of dictionaries containing the 3 required fields ("name", "type", "help") and one optional field ("default").
-    When initializing a Prefab, if a prefab property name matches a keyword argument fed to the Prefab's initializer, the property will be added to the prefab as a SOFA data of the given type.
+    Special Node to make reusable procedural objects in Sofa.
+    ---------------------------------------------------------
 
-    Prefabs have protected keyword arguments:
-    - name: the name of the prefab instance
-    - parent and parents: can't be used together, they set the context of the prefab, thus allowing paths resolution for Prefab parameters whose arguments are passed as link paths (strings). parents (with an '-s') sets multi-node contexts
-    - All other protected keyword arguments in SOFA components    
+    Inherit from this class to create your own Prefab. What makes Prefab special is that they 
+    have a set of special data named prefabParameters. When any of prefabParameter is changed the prefab
+    is completely recreated by calling the onParameterChanged method so the scene graph is always kept synchronized
+    with the parameter's content.
+
+    To specify the prefabParameters, it is possible to provide in the class a list of dictionaries containing the 3 required fields ("name", "type", "help")
+    and one optional field ("default").
+
+    The same syntax can be used to also add prefab's data.
 
     Example of use:
       .. code-block:: python
+
         import Sofa.Core
 
         class Foo(Sofa.Core.Prefab):
-            properties = [{ 'name': 'n', 'type': 'int', 'help': 'number of times this prefab prints 'message', 'default': '1'},
-                          {'name': 'message', 'type': 'string', 'help': 'message to display n times', 'default': 'Hello World!'}]
+            prefabParameters = [{ 'name': 'n', 'type': 'int', 'help': 'number of repetition, 'default': 1},
+                                {'name': 'message', 'type': 'string', 'help': 'message to display', 'default': ''}]
+
+            myAttribute = 0
 
             def __init__(self, *a, *k):
                 Sofa.Core.Prefab.__init__(self, *a, **k)
 
-            def doReInit(self):
+            def init(self):
+                myAttribute += 1
                 for i in range(0, self.n.value):
                     print(self.message.value)
 
         n = Sofa.Core.Node()
         n.addChild(Foo(name="aFooPrefab", n=42, message="hello universe!"))
+
+    Prefab has protected the following additional keywords:
+        - "name": the name of the prefab instance
+        - "parent" and "parents": can't be used together, they set the context of the prefab,
+           thus allowing paths resolution for Prefab parameters whose arguments are passed as link paths (strings). parents (with an '-s') sets multi-node contexts
+
+
     """
     def __init__(self, *args, **kwargs):
         Sofa.Core.RawPrefab.__init__(self, *args, **kwargs)
@@ -71,14 +87,42 @@ class Prefab(Sofa.Core.RawPrefab):
             if "parent" in kwargs and "parents" in kwargs:
                 Sofa.Helper.msg_error(self, "Cannot use both 'parent' and 'parents' keywords on a prefab. Use 'parent' to set the context of your prefab, 'parents' in the case of a multi-parent prefab")
         
-        # Prefab parameters are defined in a list of dictionaries named "properties".
+        # Prefab parameters are defined in a list of dictionaries named "prefabParameters".
         # The dictionaries has 3 required fields (name, type, help) and an additional optional field "default"
         docstring = ""
+
+        if hasattr(self, "prefabParameters"):
+            docstring += "Prefab's parameters:"
+            for p in self.prefabParameters:
+                self.addPrefabParameter(name=p['name'],
+                                        type=p['type'],
+                                        help=p['help'],
+                                        default=kwargs.get(p['name'], p.get('default', None)))
+                docstring += "\n:param " + p['name'] + ": " + p['help'] + ", defaults to " + str(p.get('default', '')) + '\n:type ' + p['name'] + ": " + p['type'] + "\n\n"
+
+        if hasattr(self, "prefabData"):
+            docstring += "Prefab's data:"
+            for p in self.prefabData:
+                self.addData(name=p['name'], type=p['type'], help=p['help'],
+                             value=kwargs.get(p['name'], p.get('default', None)),
+                             default=p['default'],
+                             group=p.get('group', 'Property'))
+                docstring += "\n:param " + p['name'] + ": " + p['help'] + ", defaults to " + str(p.get('default', '')) + '\n:type ' + p['name'] + ": " + p['type'] + "\n\n"
+
+        # if hasattr(self, "prefab_links"):
+        #    docstring += "Prefab's links:"
+        #    for p in self.prefab_links:
+        #        self.addLink(name=p['name'],
+        #                     help=p['help'],
+        #                     value=kwargs.get(p['name'], ""))
+        #        docstring += "\n:param " + p['name'] + ": " + p['help'] + "\n\n"
+
         if hasattr(self, "properties"):
-            docstring += ""
+            Sofa.Helper.msg_deprecated(self, "properties has been replace with prefabParameters. Please update your code.")
+            docstring += "Prefab's (properties):"
             for p in self.properties:
                 self.addPrefabParameter(name=p['name'], type=p['type'], help=p['help'], default=kwargs.get(p['name'], p.get('default', None)))
                 docstring += "\n:param " + p['name'] + ": " + p['help'] + ", defaults to " + str(p.get('default', '')) + '\n:type ' + p['name'] + ": " + p['type'] + "\n\n"
 
         self.addData("docstring", value=('' if self.__doc__ is None else self.__doc__) + docstring, type="string", group="Infos", help="Documentation of the prefab")
-        self.init()
+        self.initPrefab()

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -45,23 +45,34 @@ using namespace pybind11::literals;
 
 namespace sofapython3 {
 
-class Prefab_Trampoline : public Prefab {
+class Prefab_Trampoline : public Prefab
+{
 public:
     SOFA_CLASS(Prefab_Trampoline, Prefab);
 
-    void doReInit() override ;
+    void init() override ;
+    void onParameterChanged() override ;
 };
 
-void Prefab_Trampoline::doReInit()
+void Prefab_Trampoline::onParameterChanged()
 {
-    if (!m_is_initialized) {
-        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Loading);
-        msg_warning(this) << "Prefab instantiated. Check for required prefab parameters to fully populate";
-        return;
-    }
-    try{
+    try
+    {
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
-        PYBIND11_OVERLOAD(void, Prefab, doReInit, );
+        PYBIND11_OVERLOAD(void, Prefab, onParameterChanged, );
+    } catch (std::exception& e)
+    {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
+        msg_error(this) << e.what();
+    }
+}
+
+void Prefab_Trampoline::init()
+{
+    try
+    {
+        this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
+        PYBIND11_OVERLOAD(void, Prefab, init, );
     } catch (std::exception& e)
     {
         this->d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
@@ -108,8 +119,9 @@ void moduleAddPrefab(py::module &m) {
     f.def("setSourceTracking", &Prefab::setSourceTracking);
     f.def("addPrefabParameter", &Prefab::addPrefabParameter,
           "name"_a, "help"_a, "type"_a, "default"_a = py::none());
+    f.def("initPrefab", &Prefab::initPrefab);
     f.def("init", &Prefab::init);
-    f.def("reinit", &Prefab::reinit);
+    f.def("onParameterChanged", &Prefab::onParameterChanged);
 }
 
 

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(PYTHON_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/ForceField.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/DataEngine.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/MyRestShapeForceField.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/Core/Prefab.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseLink.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Helper/Message.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Types/RGBAColor.py

--- a/bindings/Sofa/tests/Core/Prefab.py
+++ b/bindings/Sofa/tests/Core/Prefab.py
@@ -1,0 +1,49 @@
+# coding: utf8
+import Sofa
+import numpy
+import unittest
+
+
+class MyPrefab(Sofa.Prefab):
+    prefabParameters = [
+        {"name" : "myParameter", "type" : "int", "help" : "my message to help the user", "default" : 0}
+    ]
+
+    prefabData = [
+        {"name" : "myData", "type" : "Vec3d", "help" : "my message to help the user", "default" : [0.0,0.0,0.0]}
+    ]
+
+    initCount = 0
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Prefab.__init__(self, *args, **kwargs)
+
+    def init(self):
+        for i in range(self.myParameter.value):
+            self.addChild("Child"+str(i))
+        self.addObject("MechanicalObject", name="dofs", position=self.myData.getLinkPath(), showObject=True, showObjectScale=2)
+        self.initCount += 1
+
+class Test(unittest.TestCase):
+    def test_prefab_init(self):
+        root = Sofa.Core.Node("root")
+        root.addChild(MyPrefab(name="prefab", myParameter=3, myData=[1.0,2.0,3.0]))
+
+        self.assertEqual(len(root.prefab.children), 3)
+        numpy.testing.assert_array_equal(root.prefab.myData.value, [1.0,2.0,3.0])
+        numpy.testing.assert_array_equal(root.prefab.dofs.position.value, [[1.0,2.0,3.0]])
+
+    def test_prefab_reinit(self):
+        root = Sofa.Core.Node("root")
+        root.addChild(MyPrefab(name="prefab", myParameter=3, myData=[1.0,2.0,3.0]))
+
+        self.assertEqual(len(root.prefab.children), 3)
+        self.assertEqual(root.prefab.initCount, 1)
+
+        root.prefab.myParameter = 5
+        self.assertEqual(len(root.prefab.children), 5)
+        self.assertEqual(root.prefab.initCount, 2)
+
+        root.prefab.myParameter = 6
+        self.assertEqual(len(root.prefab.children), 6)
+        self.assertEqual(root.prefab.initCount, 3)

--- a/bindings/SofaGui/Bindings.SofaGuiConfig.cmake.in
+++ b/bindings/SofaGui/Bindings.SofaGuiConfig.cmake.in
@@ -7,7 +7,6 @@ find_package(SofaPython3 QUIET REQUIRED COMPONENTS Plugin Bindings.Sofa)
 
 find_package(Sofa.GL QUIET REQUIRED)
 find_package(Sofa.Core QUIET REQUIRED)
-find_package(SofaGuiCommon QUIET REQUIRED)
 find_package(SofaGui QUIET REQUIRED)
 
 # If we are importing this config file and the target is not yet there this is indicating that

--- a/bindings/SofaGui/CMakeLists.txt
+++ b/bindings/SofaGui/CMakeLists.txt
@@ -21,7 +21,7 @@ SP3_add_python_module(
     DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      Sofa.Core SofaGuiCommon SofaGui SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+    DEPENDS      Sofa.Core SofaGui SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
 )
 
 sofa_create_component_in_package_with_targets(

--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Binding_BaseGui.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Binding_BaseGui.cpp
@@ -20,17 +20,17 @@
 
 #include "Binding_BaseGui.h"
 
-#include <sofa/gui/BaseGUI.h>
+#include <sofa/gui/common/BaseGUI.h>
 
 namespace py = pybind11;
 
 namespace sofapython3 {
-using sofa::gui::BaseGUI;
+using sofa::gui::common::BaseGUI;
 using sofa::simulation::Node;
 
 void moduleAddBaseGui(py::module& m)
 {
-    py::class_<sofa::gui::BaseGUI, std::unique_ptr<sofa::gui::BaseGUI, py::nodelete>> baseGUI(m, "BaseGUI");
+    py::class_<sofa::gui::common::BaseGUI, std::unique_ptr<sofa::gui::common::BaseGUI, py::nodelete>> baseGUI(m, "BaseGUI");
 
     /*
      * Sofa.Gui.BaseGUI.SetBackgroundImage
@@ -41,7 +41,7 @@ void moduleAddBaseGui(py::module& m)
         :param filename: Path to the image which will become the background of the viewer.
         :type filename: str
     )doc";
-    baseGUI.def("setBackgroundImage", &sofa::gui::BaseGUI::setBackgroundImage, SetBackgroundImageDoc);
+    baseGUI.def("setBackgroundImage", &sofa::gui::common::BaseGUI::setBackgroundImage, SetBackgroundImageDoc);
 
 }
 

--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Binding_GUIManager.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Binding_GUIManager.cpp
@@ -21,8 +21,8 @@
 #include <pybind11/stl.h>
 
 #include <SofaPython3/SofaGui/Binding_GUIManager.h>
-#include <sofa/gui/GUIManager.h>
-#include <sofa/gui/BaseGUI.h>
+#include <sofa/gui/common/GUIManager.h>
+#include <sofa/gui/common/BaseGUI.h>
 #include <sofa/simulation/Node.h>
 
 /// Makes an alias for the pybind11 namespace to increase readability.
@@ -32,7 +32,7 @@ namespace sofapython3 {
 
 void moduleAddGuiManager(py::module& m)
 {
-    py::class_<sofa::gui::GUIManager> guiManager(m, "GUIManager");
+    py::class_<sofa::gui::common::GUIManager> guiManager(m, "GUIManager");
 
     /*
      * Sofa.Gui.GUIManager.ListSupportedGUI
@@ -45,8 +45,8 @@ void moduleAddGuiManager(py::module& m)
         :return: A string containing each available GUIs. If the parameter 'separator' is omitted, a list containing the
                  available GUIs is returned instead of a string.
     )doc";
-    guiManager.def_static("ListSupportedGUI", py::overload_cast<>(&sofa::gui::GUIManager::ListSupportedGUI), listSupportedGUIDoc);
-    guiManager.def_static("ListSupportedGUI", py::overload_cast<char>(&sofa::gui::GUIManager::ListSupportedGUI), listSupportedGUIDoc );
+    guiManager.def_static("ListSupportedGUI", py::overload_cast<>(&sofa::gui::common::GUIManager::ListSupportedGUI), listSupportedGUIDoc);
+    guiManager.def_static("ListSupportedGUI", py::overload_cast<char>(&sofa::gui::common::GUIManager::ListSupportedGUI), listSupportedGUIDoc );
 
 
     /*
@@ -60,7 +60,7 @@ void moduleAddGuiManager(py::module& m)
         :param gui_name: The name of the GUI used. See Sofa.Gui.GUIManager.ListSupportedGUI(). (optional)
         :type  gui_name: str
     )doc";
-    guiManager.def_static("Init", &sofa::gui::GUIManager::Init, py::arg("program_name"), py::arg("gui_name") = "", initDoc);
+    guiManager.def_static("Init", &sofa::gui::common::GUIManager::Init, py::arg("program_name"), py::arg("gui_name") = "", initDoc);
 
 
     /*
@@ -76,10 +76,10 @@ void moduleAddGuiManager(py::module& m)
         :return: 0 if the GUI creation succeed, 1 otherwise
     )doc";
     guiManager.def_static("createGUI", [](sofa::simulation::Node & node, const std::string & filename) -> int {
-        return sofa::gui::GUIManager::createGUI(&node, filename.c_str());
+        return sofa::gui::common::GUIManager::createGUI(&node, filename.c_str());
     }, createGUIDoc);
     guiManager.def_static("createGUI", [](sofa::simulation::Node & node) -> int {
-        return sofa::gui::GUIManager::createGUI(&node);
+        return sofa::gui::common::GUIManager::createGUI(&node);
     }, createGUIDoc);
 
 
@@ -89,7 +89,7 @@ void moduleAddGuiManager(py::module& m)
     const auto closeGUIDoc = R"doc(
         Close the current GUI.
     )doc";
-    guiManager.def_static("closeGUI", &sofa::gui::GUIManager::closeGUI, closeGUIDoc);
+    guiManager.def_static("closeGUI", &sofa::gui::common::GUIManager::closeGUI, closeGUIDoc);
 
 
     /*
@@ -106,7 +106,7 @@ void moduleAddGuiManager(py::module& m)
         :type temporaryFile: bool
     )doc";
     guiManager.def_static("SetScene", [](sofa::simulation::Node & node, const char * filename = nullptr, bool temporaryFile = false) {
-        sofa::gui::GUIManager::SetScene(&node, filename, temporaryFile);
+        sofa::gui::common::GUIManager::SetScene(&node, filename, temporaryFile);
     }, py::arg("root"), py::arg("filename") = nullptr, py::arg("temporaryFile") = false, setSceneDoc);
 
 
@@ -125,10 +125,10 @@ void moduleAddGuiManager(py::module& m)
         :return: 0 if the main loop succeed, 1 otherwise
     )doc";
     guiManager.def_static("MainLoop", [](sofa::simulation::Node & node, const std::string & filename) -> int {
-        return sofa::gui::GUIManager::MainLoop(&node, filename.c_str());
+        return sofa::gui::common::GUIManager::MainLoop(&node, filename.c_str());
     }, mainLoopDoc);
     guiManager.def_static("MainLoop", [](sofa::simulation::Node & node) -> int {
-        return sofa::gui::GUIManager::MainLoop(&node);
+        return sofa::gui::common::GUIManager::MainLoop(&node);
     }, mainLoopDoc);
 
 
@@ -145,7 +145,7 @@ void moduleAddGuiManager(py::module& m)
         :param height:
         :type height: int
     )doc";
-    guiManager.def_static("SetDimension", &sofa::gui::GUIManager::SetDimension, setDimensionDoc);
+    guiManager.def_static("SetDimension", &sofa::gui::common::GUIManager::SetDimension, setDimensionDoc);
 
 
     /*
@@ -154,7 +154,7 @@ void moduleAddGuiManager(py::module& m)
     const auto SetFullScreenDoc = R"doc(
         Set the GUI in full screen mode.
     )doc";
-    guiManager.def_static("SetFullScreen", &sofa::gui::GUIManager::SetFullScreen, SetFullScreenDoc);
+    guiManager.def_static("SetFullScreen", &sofa::gui::common::GUIManager::SetFullScreen, SetFullScreenDoc);
 
     /*
      * Sofa.Gui.GUIManager.SaveScreenshot
@@ -165,7 +165,7 @@ void moduleAddGuiManager(py::module& m)
         :param filename: Where to save the screenshot.
         :type filename: str
     )doc";
-    guiManager.def_static("SaveScreenshot", &sofa::gui::GUIManager::SaveScreenshot, SaveScreenshotDoc);
+    guiManager.def_static("SaveScreenshot", &sofa::gui::common::GUIManager::SaveScreenshot, SaveScreenshotDoc);
 
     /*
      * Sofa.Gui.GUIManager.GetGUI
@@ -173,7 +173,7 @@ void moduleAddGuiManager(py::module& m)
     const auto GetGUIDoc = R"doc(
         Get the current GUI.
     )doc";
-    guiManager.def_static("GetGUI", &sofa::gui::GUIManager::getGUI, GetGUIDoc);
+    guiManager.def_static("GetGUI", &sofa::gui::common::GUIManager::getGUI, GetGUIDoc);
 }
 
 } /// namespace sofapython3

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ set(EXAMPLES_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/emptyController.py
     ${CMAKE_CURRENT_SOURCE_DIR}/emptyDataEngine.py
     ${CMAKE_CURRENT_SOURCE_DIR}/emptyForceField.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/example-prefab.py
     ${CMAKE_CURRENT_SOURCE_DIR}/example-forcefield.py
     ${CMAKE_CURRENT_SOURCE_DIR}/example-scriptcontroller.py
     ${CMAKE_CURRENT_SOURCE_DIR}/keyEvents.py

--- a/examples/example-prefab.py
+++ b/examples/example-prefab.py
@@ -1,0 +1,41 @@
+import Sofa
+
+class MyPrefab(Sofa.Prefab):
+    """
+    A CustomPrefab that creates a given number of child node.
+    """
+
+    # These prefabParameters are special, when any of them are changed the prefab is completely recreated by calling the method onParameterChanged(). 
+    # The scene graph is always kept synchronized with these parameters content.    
+    prefabParameters = [
+        {"name" : "myParameter", "type" : "int", "help" : "my message to help the user", "default" : 0}
+    ]  
+
+    # These prefabData are registering sofa data field to the prefab. 
+    prefabData = [
+        {"name" : "myData", "type" : "Vec3d", "help" : "my message to help the user", "default" : [0.0,0.0,0.0]}
+    ]  
+
+    # It is not possible to add properties in the __init__constructor. 
+    initCount = 0
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Prefab.__init__(self, *args, **kwargs)
+
+    def init(self):
+        """This method is called to fill the prefab's content."""
+        for i in range(self.myParameter.value):
+            self.addChild("Child"+str(i))
+        self.addObject("MechanicalObject", position=self.myData.getLinkPath(), showObject=True, showObjectScale=2)            
+        self.initCount += 1
+
+    # By default, the onParameterChanged method is calling self.init()
+    # Override this method to control when the update is done
+    #def onParameterChanged(self):
+    #    if self.initCount <= 4:
+    #        print("Update the prefab")
+    #        self.init()
+
+def createScene(root):
+    root.addChild(MyPrefab(name="MyPrefab1", myParameter=1, myData=[1.0,2.0,3.0]))
+    root.addChild(MyPrefab(name="MyPrefab2", myParameter=5))


### PR DESCRIPTION
The Prefab implementation in SofaPython3 is experimental code that has never been validated, a too complexe API and is not event fully working.

This PR fix all that and includes a basic test and a first example to demonstrate the use of Sofa.Prefab.

The general idea is that a Sofa.Prefab is a Node with extra feature to deal in a systematic way how its content  change when some of its parameters changes. 
 