### PR TITLE
[Binding] Fix broken tests that were using the old syntax to pass two dimmensional array to python.

### DIFF
--- a/bindings/Sofa/tests/Core/ForceField.py
+++ b/bindings/Sofa/tests/Core/ForceField.py
@@ -30,7 +30,7 @@ def createParticle(node, node_name, use_implicit_scheme, use_iterative_solver):
     p = node.addChild(node_name)
     createIntegrationScheme(p, use_implicit_scheme)
     createSolver(p, use_iterative_solver)
-    dofs = p.addObject('MechanicalObject', name="MO", position=[0, 0, 0])
+    dofs = p.addObject('MechanicalObject', name="MO", position=[[0, 0, 0]])
     p.addObject('UniformMass', totalMass=1.0)
 
     myRSSFF = NaiveRestShapeSpringsForcefield(name="Springs",

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
                 root = Sofa.Core.Node("rootNode")
                 root.addObject("RequiredPlugin", name="SofaBaseMechanics")
                 c = root.addChild("child1")
-                c = c.addObject("MechanicalObject", name="MO", position=[0.0,1.0,2.0]*100)
+                c = c.addObject("MechanicalObject", name="MO", position=[[0.0,1.0,2.0]]*100)
                 root.init()
                 print("TYPE: "+str(len(c.position.value)))
                 self.assertEqual(len(c.position.value), 100)


### PR DESCRIPTION
Array where passed using a now invalid syntax which does not convey the correct dimmensions. 