### PR TITLE
[FIX] The callpoint api is broken since SofaPython3. 

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -103,7 +103,8 @@ public:
 
     std::set<std::string> addedPath;
 
-    py::module m_sofamodule ;
+    py::module m_sofaModule ;
+    py::module m_sofaRuntimeModule ;
 private:
     std::vector<wchar_t*> m_argv;
 };
@@ -237,7 +238,8 @@ void PythonEnvironment::Init()
     // Lastly, we (try to) add modules from the root of SOFA
     addPythonModulePathsFromDirectory( Utils::getSofaPathPrefix() );
 
-    getStaticData()->m_sofamodule = py::module::import("Sofa");
+    getStaticData()->m_sofaModule = py::module::import("Sofa");
+    getStaticData()->m_sofaRuntimeModule = py::module::import("SofaRuntime");
     PyRun_SimpleString("import SofaRuntime");
 
     // python livecoding related
@@ -508,22 +510,15 @@ std::string PythonEnvironment::getStackAsString()
 
 std::string PythonEnvironment::getPythonCallingPointString()
 {
-    return py::cast<std::string>(getStaticData()->m_sofamodule.attr("getPythonCallingPointAsString")());
+    gil lock;
+    return py::cast<std::string>(getStaticData()->m_sofaModule.attr("getPythonCallingPointAsString")());
 }
 
 sofa::helper::logging::FileInfo::SPtr PythonEnvironment::getPythonCallingPointAsFileInfo()
 {
-    PyObject* pDict = PyModule_GetDict(PyImport_AddModule("SofaRuntime"));
-    PyObject* res = PyDict_GetItemString(pDict, "getPythonCallingPoint");
-    if(res && PySequence_Check(res) ){
-        PyObject* filename = PySequence_GetItem(res, 0) ;
-        PyObject* number = PySequence_GetItem(res, 1) ;
-        std::string tmp=PyBytes_AsString(filename);
-        auto lineno = PyLong_AsLong(number);
-        Py_DECREF(res) ;
-        return SOFA_FILE_INFO_COPIED_FROM(tmp, lineno);
-    }
-    return SOFA_FILE_INFO_COPIED_FROM("undefined", -1);
+    gil lock;
+    py::tuple cp = getStaticData()->m_sofaRuntimeModule.attr("getPythonCallingPoint")();
+    return SOFA_FILE_INFO_COPIED_FROM(py::cast<std::string>(cp[0]), py::cast<int>(cp[1]));
 }
 
 void PythonEnvironment::setArguments(const std::string& filename, const std::vector<std::string>& arguments)

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -237,7 +237,7 @@ void PythonEnvironment::Init()
     // Lastly, we (try to) add modules from the root of SOFA
     addPythonModulePathsFromDirectory( Utils::getSofaPathPrefix() );
 
-    executePython([]{ getStaticData()->m_sofamodule = py::module::import("Sofa"); });
+    executePython([]{ getStaticData()->m_sofaModule = py::module::import("Sofa"); });
     executePython([]{ getStaticData()->m_sofaRuntimeModule = py::module::import("SofaRuntime"); });
     executePython([]{ PyRun_SimpleString("import SofaRuntime");});
 

--- a/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
@@ -106,6 +106,9 @@ void SceneLoaderPY3::loadSceneWithArguments(const char *filename,
 
         py::object createScene = module.attr("createScene");
         createScene( PythonFactory::toPython(root_out.get()) );
+
+        root_out->setInstanciationSourceFileName(filename);
+        root_out->setInstanciationSourceFilePos(0);
     }catch(py::error_already_set& e)
     {
         msg_error() << "Unable to completely load the scene from file '"<< filename << "'." << msgendl

--- a/bindings/Sofa/package/prefab.py
+++ b/bindings/Sofa/package/prefab.py
@@ -1,5 +1,6 @@
 import Sofa.Core
 import inspect
+import os
 
 class Prefab(Sofa.Core.RawPrefab):
     """
@@ -34,7 +35,7 @@ class Prefab(Sofa.Core.RawPrefab):
         Sofa.Core.RawPrefab.__init__(self, *args, **kwargs)
         frame = inspect.currentframe().f_back
         frameinfo = inspect.getframeinfo(frame)
-        definedloc = (frameinfo.filename, frameinfo.lineno)
+        definedloc = (os.path.abspath(frameinfo.filename), frameinfo.lineno)
 
         self.setDefinitionSourceFileName(definedloc[0])
         self.setDefinitionSourceFilePos(definedloc[1])
@@ -43,7 +44,7 @@ class Prefab(Sofa.Core.RawPrefab):
         frame = frame.f_back
         if frame is not None:
             frameinfo = inspect.getframeinfo(frame)
-            definedloc = (frameinfo.filename, frameinfo.lineno)
+            definedloc = (os.path.abspath(frameinfo.filename), frameinfo.lineno)
             self.setInstanciationSourceFileName(definedloc[0])
             self.setInstanciationSourceFilePos(definedloc[1])
 


### PR DESCRIPTION
In runSofa, 

it is possible to get where the object has been instanciated in the scene from the scenegraph. This was working in both python2 and xml. 

This was broken with SofaPython3 so the "Go Scene" popup menu entry is always grayed out.  
The PR restore the behavior. 

NB: for complex python scene it would be better to have the full creation stack instead of just the last line... but this may be an interesting UX improvement but outside of the scope of this PR.
