### PR TITLE
Revert "Organize targets into Bindings folder"

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -34,7 +34,6 @@ add_library(SofaPython3::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 foreach(bindings_module ${BINDINGS_MODULE_LIST})
     target_link_libraries(${PROJECT_NAME} INTERFACE ${PROJECT_NAME}.${bindings_module})
-    set_target_properties(${PROJECT_NAME}.${bindings_module} PROPERTIES FOLDER "Bindings")
 endforeach()
 
 sofa_create_component_in_package_with_targets(

--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(SofaPython3::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 foreach(sofabindings_module ${SOFABINDINGS_MODULE_LIST})
 	target_link_libraries(${PROJECT_NAME} INTERFACE ${PROJECT_NAME}.${sofabindings_module})
-	set_target_properties(${PROJECT_NAME}.${sofabindings_module} PROPERTIES FOLDER "Bindings/Sofa")
 endforeach()
 
 if(SP3_BUILD_TEST)


### PR DESCRIPTION
Reverts sofa-framework/SofaPython3#269

Due to old version of cmake which does not handle setting the folder property on INTERFACE_LIBRARY
```
CMake Error in applications/plugins/SofaPython3/bindings/Modules/CMakeLists.txt:
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "FOLDER" is not allowed. 
  ```
  (output from a old version of cmake)