### PR TITLE
[CMake] FIX missing find_package in Config

### DIFF
--- a/bindings/Sofa/Bindings.SofaConfig.cmake.in
+++ b/bindings/Sofa/Bindings.SofaConfig.cmake.in
@@ -7,6 +7,10 @@ find_package(SofaPython3 QUIET REQUIRED COMPONENTS Plugin)
 
 # Required by Bindings.Sofa.Components, Bindings.Sofa.Core, Bindings.Sofa.Helper, Bindings.Sofa.Simulation, Bindings.Sofa.Types, Bindings.SofaGui
 find_package(SofaFramework QUIET REQUIRED)
+# Required by Bindings.Sofa.Core
+find_package(SofaBaseCollision QUIET REQUIRED)
+find_package(SofaBaseVisual QUIET REQUIRED)
+find_package(SofaBaseUtils QUIET REQUIRED)
 # Required by Bindings.Sofa.Simulation, Bindings.SofaRuntime
 find_package(SofaSimulationGraph QUIET REQUIRED)
 


### PR DESCRIPTION
Needed to configure any project with a dependency on SofaPython3.