### PR TITLE
[SofaPyhon3/Plugin] Fix regression introduced in PR #243

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -294,7 +294,7 @@ size_t getSize(BaseData* self)
 
 py::buffer_info toBufferInfo(BaseData& m)
 {
-    scoped_read_access guard(&m);
+    m.updateIfDirty();
 
     const AbstractTypeInfo& nfo { *m.getValueTypeInfo() };
     auto itemNfo = nfo.BaseType();


### PR DESCRIPTION
To fix memory error in PR #243 there is the need to get the latest data by calling getValue().
The way it was done in the 243 PR is wrong because it is using a begin/end edit pairs which trigger the DDG's followers (and not only precessors) which in return notify that the data is not eddited anymoer (while it was not editted at all). The consequence was that every call on read access on the python side eg: print(myobject.position.value)
was triggering the data change mecanisme to the position's follower.