### PR TITLE
[FIX] Remove SofaLinearSolver in BindingsConfig.cmake.in

### DIFF
--- a/bindings/BindingsConfig.cmake.in
+++ b/bindings/BindingsConfig.cmake.in
@@ -11,7 +11,6 @@ find_package(SofaPython3 QUIET REQUIRED COMPONENTS
     Bindings.SofaGui
     Bindings.SofaRuntime
     Bindings.SofaTypes
-    Bindings.SofaLinearSolver
     )
 if(SP3_WITH_SOFAEXPORTER)
     find_package(SofaPython3 QUIET REQUIRED COMPONENTS Bindings.SofaExporter)


### PR DESCRIPTION
Because SofaLinearSolver is in module. And when imported this fails prevent to compile plugins that rely on SofaPython3.