### PR TITLE
[SofaPython3] Separates the pre-loaded python modules out of the python (Fix issue #283)

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -52,6 +52,7 @@ using sofa::simulation::SceneLoader ;
 
 /// Forward definition
 class PythonEnvironmentData ;
+class PythonEnvironmentModule ;
 
 class SOFAPYTHON3_API PythonEnvironment
 {
@@ -154,6 +155,7 @@ public:
 
 private:
     static PythonEnvironmentData* getStaticData() ;
+    static PythonEnvironmentModule* getStaticModule() ;
     static std::string pluginLibraryPath;
     static inline bool s_isInitialized{false};
 };


### PR DESCRIPTION
The execution of SOFA from a python3 environement is not working anymore because
some features need Sofa & SofaRuntime modules to be loaded but the loading is done when
initializing only in the embeded python interpreter.

To fix this, the PR move the module loading and access into its own singleton that initialize at
first use.

Fixing that is important for 22.06 release.
For the future, refactoring the PythonEnvironment file to split PythonEnvironment in two, to separate what is actually relevant for the PythonEnvironment and what
should be part something like PythonEmbededInterpreter.

Fix #283