### PR TITLE
[SofaPython3/Plugin] Add GetCustomClassName to Prefab

### DIFF
--- a/Plugin/src/SofaPython3/Prefab.h
+++ b/Plugin/src/SofaPython3/Prefab.h
@@ -59,6 +59,8 @@ public:
     void reinit();
     virtual void doReInit() ;
 
+    static const std::string GetCustomClassName(){ return "Prefab"; }
+
     void addPrefabParameter(const std::string& name, const std::string& help, const std::string& type, pybind11::object defaultValue = pybind11::none());
     void setSourceTracking(const std::string& filename);
     void breakPrefab();


### PR DESCRIPTION
So the string returned is now "Prefab" instead of "Node"

Which leads to clearly show in GUIs the fact it is a prefab and not a simple Node. 
![prefab](https://user-images.githubusercontent.com/12644882/178772486-6f0120db-b4b1-4272-aeda-6fc745236bd6.png)
