### PR TITLE
[Binding/Sofa.Core] PointSetTopologyModifier

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseMeshTopology.cpp
@@ -39,7 +39,7 @@ namespace sofapython3 {
 void moduleAddBaseMeshTopology(py::module& m) {
     py::class_<BaseMeshTopology, Base, py_shared_ptr<BaseMeshTopology>> c (m, "BaseMeshTopology");
 
-    /// register the ContactListener binding in the downcasting subsystem
+    /// register the BaseMeshTopology binding in the downcasting subsystem
     PythonFactory::registerType<BaseMeshTopology>([](sofa::core::objectmodel::Base* object)
     {
         return py::cast(dynamic_cast<BaseMeshTopology*>(object));

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_PointSetTopologyModifier.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_PointSetTopologyModifier.cpp
@@ -1,0 +1,63 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_BaseContext.h>
+#include <SofaPython3/Sofa/Core/Binding_PointSetTopologyModifier.h>
+#include <pybind11/stl.h>
+#include <sofa/component/topology/container/dynamic/PointSetTopologyModifier.h>
+
+typedef sofa::component::topology::container::dynamic::PointSetTopologyModifier PointSetTopologyModifier;
+typedef sofa::core::topology::BaseMeshTopology::PointID PointID;
+
+namespace py {
+using namespace pybind11;
+}
+
+using namespace sofa::core::objectmodel;
+using namespace sofa::core::topology;
+
+namespace sofapython3 {
+
+void moduleAddPointSetTopologyModifier(py::module& m) {
+  py::class_<PointSetTopologyModifier, Base, py_shared_ptr<PointSetTopologyModifier>> c(m, "PointSetTopologyModifier");
+
+  /// register the PointSetTopologyModifier binding in the downcasting subsystem
+  PythonFactory::registerType<PointSetTopologyModifier>([](sofa::core::objectmodel::Base* object) {
+    return py::cast(dynamic_cast<PointSetTopologyModifier*>(object));
+  });
+
+  c.def("addPoints",
+        [](PointSetTopologyModifier& self, const sofa::Size nPoints, const bool addDOF) {
+          self.addPoints(nPoints, addDOF);
+        });
+  c.def("removePoints",
+        [](PointSetTopologyModifier& self, const std::vector<unsigned int>& indices, const bool removeDOF) {
+          sofa::type::vector<PointID> index_vector;
+          index_vector.reserve(indices.size());
+          for (const auto i : indices) {
+            index_vector.emplace_back(i);
+          }
+
+          self.removePoints(index_vector, removeDOF);
+        });
+}
+
+}  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_PointSetTopologyModifier.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_PointSetTopologyModifier.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddPointSetTopologyModifier(pybind11::module &m);
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -26,6 +26,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_NodeIterator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_PointSetTopologyModifier.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Prefab.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Prefab_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataContainer.h
@@ -64,6 +65,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ObjectFactory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_NodeIterator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_PointSetTopologyModifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Prefab.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_PythonScriptEvent.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -39,6 +39,7 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Binding_NodeIterator.h>
 #include <SofaPython3/Sofa/Core/Binding_Prefab.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseLink.h>
+#include <SofaPython3/Sofa/Core/Binding_PointSetTopologyModifier.h>
 #include <SofaPython3/Sofa/Core/Binding_PythonScriptEvent.h>
 #include <SofaPython3/Sofa/Core/Binding_Topology.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseMeshTopology.h>
@@ -123,6 +124,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddBaseLink(core);
     moduleAddTopology(core);
     moduleAddBaseMeshTopology(core);
+    moduleAddPointSetTopologyModifier(core);
 }
 
 } ///namespace sofapython3

--- a/examples/pointSetTopologyModifier.py
+++ b/examples/pointSetTopologyModifier.py
@@ -1,0 +1,38 @@
+import Sofa
+import Sofa.Core
+import numpy as np
+
+
+def createScene(root):
+    root.gravity = [0, -9.81, 0]
+
+    root.addObject("DefaultAnimationLoop")
+    root.addObject("DefaultVisualManagerLoop")
+    root.addObject("RequiredPlugin", name="Sofa.Component.Topology.Container.Dynamic")
+
+    container = root.addObject("PointSetTopologyContainer", points=[[0, 0, 0], [1, 0, 0]])
+    modifier = root.addObject("PointSetTopologyModifier")
+    state = root.addObject("MechanicalObject", template="Vec3d", showObject=True, showObjectScale=10)
+
+    root.addObject(PointController(modifier=modifier, state=state, container=container))
+
+
+class PointController(Sofa.Core.Controller):
+    def __init__(self, modifier, state, container):
+        super().__init__()
+        self.container = container
+        self.modifier = modifier
+        self.state = state
+
+    def onKeypressedEvent(self, event):
+        if event["key"] == "A":
+            print("Add 10 points")
+            self.modifier.addPoints(10, True)
+
+            with self.state.position.writeable() as state:
+                for i in range(len(state)):
+                    state[i] = np.array([i, 0, 0])
+
+        elif event["key"] == "D":
+            print("Remove point 0")
+            self.modifier.removePoints(np.array([0]), True)

--- a/examples/pointSetTopologyModifier.py
+++ b/examples/pointSetTopologyModifier.py
@@ -28,11 +28,17 @@ class PointController(Sofa.Core.Controller):
         if event["key"] == "A":
             print("Add 10 points")
             self.modifier.addPoints(10, True)
-
-            with self.state.position.writeable() as state:
-                for i in range(len(state)):
-                    state[i] = np.array([i, 0, 0])
+            # print("Before setting positions", self.state.position.array())
 
         elif event["key"] == "D":
             print("Remove point 0")
             self.modifier.removePoints(np.array([0]), True)
+
+        elif event["key"] == "B":
+            print(f"{len(self.state.position.array())=}")
+            with self.state.position.writeable() as state:
+                print(f"{len(state)=}")
+                # for i in range(len(state)):
+                #     state[i] = np.array([i, 0, 0])
+
+            # print("After setting positions", self.state.position.array())


### PR DESCRIPTION
I want to add bindings for `PointSetTopologyModifier`'s `addPoints` and `removePoints` in order to change the size of a `PointSetTopologyContainer` that are propagated to components that are linked with the container (e.g. `MechanicalObject`, `RestShapeSpringsForceField`, `FixedConstraint`, ...).

Work in Progress, because the binding does not work as expected and I could use some help on that.
I added an example in https://github.com/ScheiklP/SofaPython3/blob/point_topology_modifier/examples/pointSetTopologyModifier.py

On first call, `addPoints` works as expected, every call after that does not. `removePoints` works well, but validity of point to be removed is not checked yet. Should `renumber` also be called?

https://user-images.githubusercontent.com/29635054/180652221-76295c4d-7b2c-4e59-9476-20c48cc35abf.mp4

Also if I try to open the `MechanicalObject` from within the GUI **after** modifying the topology, I get a SegFault.


