### PR TITLE
Fixed Memory Leak in DataContainer.array() and DataContainer.writeable()

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
@@ -149,7 +149,7 @@ void moduleAddDataContainer(py::module& m)
     }, sofapython3::doc::datacontainer::__len__);
 
     p.def("array", [](DataContainer* self){
-        auto capsule = py::capsule(new Base::SPtr(self->getOwner()));
+        auto capsule = py::capsule(self->getOwner());
         py::buffer_info ninfo = toBufferInfo(*self);
         py::array a(pybind11::dtype(ninfo), ninfo.shape,
                     ninfo.strides, ninfo.ptr, capsule);
@@ -160,18 +160,18 @@ void moduleAddDataContainer(py::module& m)
     p.def("writeable", [](DataContainer* self, py::object f) -> py::object
     {
         if(self!=nullptr)
-            return py::cast(new DataContainerContext(self, f));
+            return py::cast(std::make_unique<DataContainerContext>(self, f));
 
         return py::none();
-    });
+    }, py::return_value_policy::move);
 
     p.def("writeable", [](DataContainer* self) -> py::object
     {
         if(self!=nullptr)
-            return py::cast(new DataContainerContext(self, py::none()));
+            return py::cast(std::make_unique<DataContainerContext>(self, py::none()));
 
         return py::none();
-    });
+    }, py::return_value_policy::move);
 
     p.def("__iadd__", [](DataContainer* self, py::object value)
     {


### PR DESCRIPTION
As reported in https://github.com/sofa-framework/SofaPython3/issues/292 the read (`.array()`) and write (`.writeable()`) functions of `DataContainer` have a memory leak.

This PR fixes them by
- `DataContainer.array()` -> removed unnecessary pointer creation that was not cleaned up
- `DataContainer.writeable()` -> made the created pointers unique

