### PR TITLE
[Plugin] FIX environment init on Windows install

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -401,8 +401,19 @@ void PythonEnvironment::addPythonModulePathsFromPlugin(const std::string& plugin
         Plugin p = elem.second;
         if ( p.getModuleName() == pluginName )
         {
-            std::string pluginLibraryPath = elem.first;
+            // 1. Try to find the plugin directory starting from SOFA root
+            for ( auto path : sofa::helper::system::PluginRepository.getPaths() )
+            {
+                std::string pluginRoot = FileSystem::cleanPath( path + "/" + pluginName );
+                if ( FileSystem::exists(pluginRoot) && FileSystem::isDirectory(pluginRoot) )
+                {
+                    addPythonModulePathsFromDirectory(pluginRoot);
+                    return;
+                }
+            }
 
+            // 2. Try to find the plugin directory starting from the plugin library
+            std::string pluginLibraryPath = elem.first;
             // moduleRoot can be 1 or 2 levels above the library directory
             // like "plugin_name/lib/plugin_name.so"
             // or "sofa_root/bin/Release/plugin_name.dll"
@@ -413,7 +424,6 @@ void PythonEnvironment::addPythonModulePathsFromPlugin(const std::string& plugin
                 moduleRoot = FileSystem::getParentDirectory(moduleRoot);
                 maxDepth++;
             }
-
             addPythonModulePathsFromDirectory(moduleRoot);
             return;
         }


### PR DESCRIPTION
This line: https://github.com/sofa-framework/SofaPython3/blob/master/Plugin/src/SofaPython3/PythonEnvironment.cpp#L255
is not working as expected with an installed SofaPython3 on Windows.

We want PythonEnvironment to auto-add SofaPython3's site-packages but on Windows the SofaPython3.dll is copied in bin (for dependency finding reasons), leading addPythonModulePathsFromPlugin to fail finding SofaPython3's site-packages.

I added another way of searching, keeping the old way as fallback.