### PR TITLE
[Example/Tests] Add events in the constraint solver pipeline

### DIFF
--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PYTHON_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseData.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Base.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseObject.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/Core/BuildConstraintSystemEndEvent.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Controller.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/ForceField.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Mass.py

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set(PYTHON_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseData.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Base.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/BaseObject.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/Core/BuildConstraintSystemEndEvent.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/Core/Events.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Controller.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/ForceField.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Mass.py

--- a/bindings/Sofa/tests/Core/BuildConstraintSystemEndEvent.py
+++ b/bindings/Sofa/tests/Core/BuildConstraintSystemEndEvent.py
@@ -1,0 +1,63 @@
+# coding: utf8
+
+import unittest
+import Sofa
+import Sofa.Core
+import Sofa.Simulation
+import SofaRuntime
+
+
+
+class MyController(Sofa.Core.Controller):
+    """This is my custom controller
+        when init is called from Sofa this should call the python init function
+    """        
+
+    def __init__(self, *args, **kwargs):
+        ## These are needed (and the normal way to override from a python class)
+        Sofa.Core.Controller.__init__(self, *args, **kwargs)
+        self.inited = 0
+        self.iterations = 0
+
+    def __del__(self):
+            pass
+    
+    def init(self):
+            self.inited += 1
+
+    def onEvent(self, kwargs):
+            pass
+
+    def onBuildConstraintSystemEndEvent(self, kwargs):
+            self.iterations+=1
+
+
+class Test(unittest.TestCase):
+
+    def test_events(self):
+        """Test the BuildConstraintSystem event."""
+        node = Sofa.Core.Node("root")
+        node.addObject("DefaultAnimationLoop", name="loop")
+        controller = node.addObject( MyController() )
+
+        self.assertTrue( hasattr(controller, "iterations") )
+
+        Sofa.Simulation.init(node)
+        for i in range(10):
+            Sofa.Simulation.animate(node, 0.01)
+
+        self.assertTrue( hasattr(controller, "iterations") )
+        self.assertEqual( controller.iterations, 10 )
+
+
+    @staticmethod
+    def simulate_beam(linear_solver_template):
+        root = Sofa.Core.Node("rootNode")
+
+        root.addObject('DefaultAnimationLoop')
+
+        root.addObject('EulerImplicitSolver', rayleighStiffness="0.1", rayleighMass="0.1")
+        root.addObject('SparseLDLSolver', applyPermutation="false", template=linear_solver_template)
+
+        return root
+

--- a/bindings/Sofa/tests/Core/Events.py
+++ b/bindings/Sofa/tests/Core/Events.py
@@ -10,7 +10,7 @@ import SofaRuntime
 class MyController(Sofa.Core.Controller):
     """This is my custom controller
         when init is called from Sofa this should call the python init function
-    """        
+    """
 
     def __init__(self, *args, **kwargs):
         ## These are needed (and the normal way to override from a python class)
@@ -20,29 +20,29 @@ class MyController(Sofa.Core.Controller):
         self.solve_iterations = 0
 
     def __del__(self):
-            pass
-    
+        pass
+
     def init(self):
-            self.inited += 1
+        self.inited += 1
 
     def onEvent(self, kwargs):
-            pass
+        pass
 
     def onBuildConstraintSystemEndEvent(self, kwargs):
-            self.build_iterations+=1
+        self.build_iterations+=1
 
     def onSolveConstraintSystemEndEvent(self, kwargs):
-            self.solve_iterations+=1
+        self.solve_iterations+=1
 
 class Test(unittest.TestCase):
 
     def test_events(self):
         """Test the BuildConstraintSystem and SolveConstraintSystem events."""
         node = Sofa.Core.Node("root")
-        node.addObject("DefaultAnimationLoop", name="loop")
+        node.addObject("RequiredPlugin", name="Sofa.Component.AnimationLoop")
+        node.addObject("FreeMotionAnimationLoop", name="loop")
+        node.addObject("GenericConstraintSolver", name="constraintSolver")
         controller = node.addObject( MyController() )
-
-        self.assertTrue( hasattr(controller, "iterations") )
 
         Sofa.Simulation.init(node)
         for i in range(10):

--- a/bindings/Sofa/tests/Core/Events.py
+++ b/bindings/Sofa/tests/Core/Events.py
@@ -7,7 +7,6 @@ import Sofa.Simulation
 import SofaRuntime
 
 
-
 class MyController(Sofa.Core.Controller):
     """This is my custom controller
         when init is called from Sofa this should call the python init function
@@ -17,7 +16,8 @@ class MyController(Sofa.Core.Controller):
         ## These are needed (and the normal way to override from a python class)
         Sofa.Core.Controller.__init__(self, *args, **kwargs)
         self.inited = 0
-        self.iterations = 0
+        self.build_iterations = 0
+        self.solve_iterations = 0
 
     def __del__(self):
             pass
@@ -29,13 +29,15 @@ class MyController(Sofa.Core.Controller):
             pass
 
     def onBuildConstraintSystemEndEvent(self, kwargs):
-            self.iterations+=1
+            self.build_iterations+=1
 
+    def onSolveConstraintSystemEndEvent(self, kwargs):
+            self.solve_iterations+=1
 
 class Test(unittest.TestCase):
 
     def test_events(self):
-        """Test the BuildConstraintSystem event."""
+        """Test the BuildConstraintSystem and SolveConstraintSystem events."""
         node = Sofa.Core.Node("root")
         node.addObject("DefaultAnimationLoop", name="loop")
         controller = node.addObject( MyController() )
@@ -46,18 +48,10 @@ class Test(unittest.TestCase):
         for i in range(10):
             Sofa.Simulation.animate(node, 0.01)
 
-        self.assertTrue( hasattr(controller, "iterations") )
-        self.assertEqual( controller.iterations, 10 )
+        self.assertTrue( hasattr(controller, "build_iterations") )
+        self.assertEqual( controller.build_iterations, 10 )
 
+        self.assertTrue( hasattr(controller, "solve_iterations") )
+        self.assertEqual( controller.solve_iterations, 10 )
 
-    @staticmethod
-    def simulate_beam(linear_solver_template):
-        root = Sofa.Core.Node("rootNode")
-
-        root.addObject('DefaultAnimationLoop')
-
-        root.addObject('EulerImplicitSolver', rayleighStiffness="0.1", rayleighMass="0.1")
-        root.addObject('SparseLDLSolver', applyPermutation="false", template=linear_solver_template)
-
-        return root
 

--- a/examples/access_compliance_matrix.py
+++ b/examples/access_compliance_matrix.py
@@ -48,7 +48,7 @@ class MatrixAccessController(Sofa.Core.Controller):
         Sofa.Core.Controller.__init__(self, *args, **kwargs)
         self.constraint_solver = kwargs.get("constraint_solver")
 
-    def onAnimateEndEvent(self, event):
+    def onBuildConstraintSystemEndEvent(self, event):
         compliance_matrix = self.constraint_solver.W()
 
         print('====================================')
@@ -61,6 +61,8 @@ class MatrixAccessController(Sofa.Core.Controller):
         with np.printoptions(precision=3, suppress=False, threshold=np.inf):
             print(str(compliance_matrix))
 
+    def onSolveConstraintSystemEndEvent(self, event):
+        
         print('====================================')
         print('Lambda force')
         print('====================================')


### PR DESCRIPTION
This PR implements unit tests for PR #3418 from SOFA.
The example _access_compliance_matrix_ is extended through using the two new types of event, **BuildConstraintSystemEndEvent** and **SolveConstraintSystemEndEvent**.
