### PR TITLE
Add a counter to memcach so that we can detect data change

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -247,9 +247,9 @@ py::slice toSlice(const py::object& o)
 }
 
 
-std::map<void*, py::array>& getObjectCache()
+std::map<void*, std::pair<int, py::array>>& getObjectCache()
 {
-    static std::map<void*, py::array> s_objectcache {} ;
+    static std::map<void*, std::pair<int, py::array>> s_objectcache {} ;
     return s_objectcache;
 }
 
@@ -324,7 +324,7 @@ py::buffer_info toBufferInfo(BaseData& m)
     // TODO add nfo.Text()
     /* } else if(nfo.Text()) { */
     /*     format = py::format_descriptor<char>::value; */
-    /* } */ 
+    /* } */
     }
     else {
         throw py::type_error("Invalid type");
@@ -423,14 +423,15 @@ py::array resetArrayFor(BaseData* d)
     py::array a(pybind11::dtype(ninfo), ninfo.shape,
                 ninfo.strides, ninfo.ptr, capsule);
 
-    memcache[d] = a;
+    memcache[d] = std::make_pair(d->getCounter(), a);
     return a;
 }
 
 py::array getPythonArrayFor(BaseData* d)
 {
     auto& memcache = getObjectCache();
-    if(d->isDirty() || memcache.find(d) == memcache.end())
+    auto mementry = memcache.find(d);
+    if(d->isDirty() || mementry == memcache.end() || std::get<0>(mementry->second) != d->getCounter())
     {
         auto capsule = py::capsule(new Base::SPtr(d->getOwner()), [](void*p){ delete static_cast<Base::SPtr*>(p); } );
 
@@ -438,10 +439,10 @@ py::array getPythonArrayFor(BaseData* d)
         py::array a(pybind11::dtype(ninfo), ninfo.shape,
                     ninfo.strides, ninfo.ptr, capsule);
 
-        memcache[d] = a;
+        memcache[d] = std::make_pair(d->getCounter(), a);
         return a;
     }
-    return memcache[d];
+    return std::get<1>(memcache[d]);
 }
 
 

--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -193,7 +193,7 @@ SOFAPYTHON3_API pybind11::slice toSlice(const pybind11::object& o);
 SOFAPYTHON3_API std::string getPathTo(Base* b);
 SOFAPYTHON3_API const char* getFormat(const AbstractTypeInfo& nfo);
 
-SOFAPYTHON3_API std::map<void*, pybind11::array>& getObjectCache();
+SOFAPYTHON3_API std::map<void*, std::pair<int, pybind11::array>>& getObjectCache();
 SOFAPYTHON3_API void trimCache();
 
 SOFAPYTHON3_API bool hasArrayFor(BaseData* d);

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -207,7 +207,6 @@ class Test(unittest.TestCase):
         self.assertRaises(AttributeError, (lambda aa: aa.unvalid), p)
 
     # @unittest.skip  # no reason needed
-
     def test_DataArray2DOperation(self):
         root = create_scene("rootNode")
         v = numpy.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 3]])
@@ -247,6 +246,36 @@ class Test(unittest.TestCase):
         def t(c):
             c[0] = 1.0
         self.assertRaises(ValueError, (lambda c: t(c)), color)
+
+    def test_DataAsContainerNumpyArray_testIsDirtyOnDoubleAccess_(self):
+        root = create_scene("rootNode")
+
+        root.addObject("PointSetTopologyContainer", points=[[0, 0, 0], [1, 0, 0]])
+        modifier = root.addObject("PointSetTopologyModifier")
+        mo = root.addObject("MechanicalObject")
+        Sofa.Simulation.init(root)
+
+        modifier.addPoints(10, True)
+        self.assertEqual(len(mo.position), 12)
+
+        modifier.addPoints(10, True)
+        self.assertEqual(len(mo.position), 22)
+
+    def test_DataAsContainerNumpyArray_testIsDirtyOnDoubleWriteAccess_(self):
+        root = create_scene("rootNode")
+
+        root.addObject("PointSetTopologyContainer", points=[[0, 0, 0], [1, 0, 0]])
+        modifier = root.addObject("PointSetTopologyModifier")
+        mo = root.addObject("MechanicalObject")
+        Sofa.Simulation.init(root)
+
+        modifier.addPoints(10, True)
+        with mo.position.writeable() as w:
+            self.assertEqual(len(w), 12)
+
+        modifier.addPoints(10, True)
+        with mo.position.writeable() as w:
+            self.assertEqual(len(w), 22)
 
     def test_DataAsContainerNumpyArray_(self):
         root = create_scene("rootNode")
@@ -319,10 +348,10 @@ class Test(unittest.TestCase):
         root1 = create_scene("root1")
         root1.addChild("child1")
         root2 = create_scene("root2")
-        root2.addChild("child2)
+        root2.addChild("child2")
         root1.child1.addObject("MechanicalObject", name="dofs1", position=[[1.0,2.0,3.0]])
-        root2.chdil2.addObject("MechanicalObject", name="dofs2", position=root1.child1.dofs1.position.linkpath)
-        self.assertEqual(root2.dofs2.position.getParent().name, "dofs1")
+        root2.child2.addObject("MechanicalObject", name="dofs2", position=root1.child1.dofs1.position.linkpath)
+        self.assertEqual(str(root2.child2.dofs2.position.getParent().linkpath), "@/child1/dofs1.position")
 
     def test_set_value_from_string(self):
         n = create_scene("rootNode")


### PR DESCRIPTION
The issue 313 shows that the memcache is not updated when the data have changed but the flag is not anymore dirty. This happens when between the change and the call to the writeable() function somewhere else in Sofa, a component/controller/the gui had called the updateIfDirty() method. 

In order to detect the "no more dirty but changed data" a counter is added to the memcache enties so we can detect if it is different from the counter stored in the BaseData. 

fix issue #313 

The PR also restore all the tests in Base.py  that are failing silently since a long time (the fact that parse error in python tests can get un-noticed is very problematic, we should fix that one day.). 
