### PR TITLE
[DataHelper] Change default access of vector data buffer 

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -334,7 +334,10 @@ py::buffer_info toBufferInfo(BaseData& m)
 
     std::tuple<int,int> shape = getShape(&m);
 
-    void* ptr = const_cast<void*>(nfo.getValuePtr(m.getValueVoidPtr()));
+
+    void* ptr = nullptr;
+    if (std::get<0>(shape) != 0)
+        ptr = const_cast<void*>(nfo.getValuePtr(m.getValueVoidPtr()));
 
     if( !itemNfo->Container() ){
         return py::buffer_info(

--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -334,7 +334,7 @@ py::buffer_info toBufferInfo(BaseData& m)
 
     std::tuple<int,int> shape = getShape(&m);
 
-
+    // By default, ptr is set to nullptr. It is updated by a call to getValuePtr only if the data is not empty. Otherwise the ptr passed to the py::buffer_info remains nullptr. 
     void* ptr = nullptr;
     if (std::get<0>(shape) != 0)
         ptr = const_cast<void*>(nfo.getValuePtr(m.getValueVoidPtr()));


### PR DESCRIPTION
When accessing a data vector through Python scripting, the `py::buffer_info` structure returned by the `toBufferInfo` method contains a pointer to the vector data buffer. By default this pointer is retrieved thanks to SOFA's `getValuePtr` method, which in the end returns a reference to the vector's first element (`&data[0]` cf in _VectorTypeInfo.h_). This leads to an undefined behaviour when the data vector is empty (i.e.: data[0] doesn't exist).

This PR adds a safeguard in _DataHelper_, checking the size of the vector before calling `getValuePtr`. If the vector is empty (size = 0), we pass a null pointer to the final `py::buffer_info` structure.
As I'm not fully aware of the consequences of this change, this PR is also open to discussion.

NB: a different PR is open in SOFA [(link)](https://github.com/sofa-framework/sofa/pull/3505) to deal with the behaviour of `getValuePtr`