### PR TITLE
Add addObject spelling support (again)

### DIFF
--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -5,6 +5,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/initModule.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonEnvironment.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SceneLoaderPY3.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SpellingSuggestionHelper.h
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/DataCache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/DataHelper.h

--- a/Plugin/src/SofaPython3/SpellingSuggestionHelper.h
+++ b/Plugin/src/SofaPython3/SpellingSuggestionHelper.h
@@ -1,0 +1,55 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <functional>
+#include <algorithm>
+#include <iostream>
+#include <sofa/helper/DiffLib.h>
+
+namespace sofapython3
+{
+
+template<class Iterable, class UnaryOperation, class PickingFunction>
+void fillVectorOfStringFrom(const Iterable& v, const UnaryOperation& op, const PickingFunction func)
+{
+    std::transform(v.begin(), v.end(), op, func);
+}
+
+template<class Iterable, class PickingFunction=std::function<const std::string(typename Iterable::value_type)> >
+std::ostream& emitSpellingMessage(std::ostream& ostream, const std::string& message, const Iterable& iterable, const std::string& name,
+                                  sofa::Size numEntries=5, SReal thresold=0.6_sreal,
+                                  PickingFunction f = [](const typename Iterable::value_type d) { return d->getName(); })
+{
+    std::vector<std::string> possibleNames;
+    possibleNames.reserve(iterable.size());
+    fillVectorOfStringFrom(iterable, std::back_inserter(possibleNames), f);
+
+    auto spellingSuggestions = sofa::helper::getClosestMatch(name, possibleNames, numEntries, thresold);
+    if(!spellingSuggestions.empty())
+    {
+        for(auto& [name, score] : spellingSuggestions)
+           ostream << message << "'" << name << "' ("<< std::to_string((int)(100*score))+"% match)" << std::endl;
+    }
+    return ostream;
+}
+
+
+}

--- a/Plugin/src/SofaPython3/SpellingSuggestionHelper.h
+++ b/Plugin/src/SofaPython3/SpellingSuggestionHelper.h
@@ -45,8 +45,8 @@ std::ostream& emitSpellingMessage(std::ostream& ostream, const std::string& mess
     auto spellingSuggestions = sofa::helper::getClosestMatch(name, possibleNames, numEntries, thresold);
     if(!spellingSuggestions.empty())
     {
-        for(auto& [name, score] : spellingSuggestions)
-           ostream << message << "'" << name << "' ("<< std::to_string((int)(100*score))+"% match)" << std::endl;
+        for(auto& [suggestedName, score] : spellingSuggestions)
+           ostream << message << "'" << suggestedName<< "' ("<< std::to_string((int)(100*score))+"% match)" << std::endl;
     }
     return ostream;
 }

--- a/Plugin/src/SofaPython3/config.h.in
+++ b/Plugin/src/SofaPython3/config.h.in
@@ -55,3 +55,18 @@
 #else
 #define SOFAPYTHON3_BIND_ATTRIBUTE_ERROR() namespace pybind11 { PYBIND11_RUNTIME_EXCEPTION(attribute_error, PyExc_AttributeError) }
 #endif // PYBIND11_SOFA_VERSION >= 20801
+
+#if PYBIND11_SOFA_VERSION >= 20600
+#define SOFAPYTHON3_ADD_PYBIND_TYPE_FOR_OLD_VERSION()
+#else
+#define SOFAPYTHON3_ADD_PYBIND_TYPE_FOR_OLD_VERSION() namespace pybind11 { \
+class type : public pybind11::object { \
+public: \
+    PYBIND11_OBJECT(type, pybind11::object, PyType_Check) \
+    static pybind11::handle handle_of(pybind11::handle h) { return handle((PyObject*) Py_TYPE(h.ptr())); } \
+    static type of(pybind11::handle h) { return type(type::handle_of(h), borrowed_t{}); } \
+    template<typename T> static handle handle_of(); \
+    template<typename T> static type of() {return type(type::handle_of<T>(), borrowed_t{}); } \
+}; \
+}
+#endif // PYBIND11_SOFA_VERSION >= 20801


### PR DESCRIPTION
Same as #314 but with 2.6.0 setting for the backward compatibility to old pybind11 version.
py::type was introduced at 2.6.0 so there is no need for the macro after that.

The previous merged problem was not detected before because pybind11 on sofa-jenkins is 2.6.2 while pybind11 on sofapython/github actions is 2.4. 