### PR TITLE
Fix: mass binding is defined to have multiple inheritance

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Mass.cpp
@@ -43,7 +43,7 @@ using sofa::core::behavior::Mass;
 template<class TDOFType>
 void declare_mass(py::module &m) {
     const std::string pyclass_name = std::string("Mass") + TDOFType::Name();
-    py::class_<Mass<TDOFType>, sofa::core::behavior::ForceField<TDOFType>, py_shared_ptr<Mass<TDOFType>>> f(m, pyclass_name.c_str(), sofapython3::doc::mass::massClass);
+    py::class_<Mass<TDOFType>, sofa::core::behavior::ForceField<TDOFType>, py_shared_ptr<Mass<TDOFType>>> f(m, pyclass_name.c_str(), py::multiple_inheritance(), sofapython3::doc::mass::massClass);
 
     using Real = typename TDOFType::Real;
     using EigenSparseMatrix = Eigen::SparseMatrix<typename TDOFType::Real, Eigen::RowMajor>;


### PR DESCRIPTION
This is a fix for https://github.com/sofa-framework/BeamAdapter/discussions/86

The call of `assembleKMatrix` leads to a UB without the suggested change.