### PR TITLE
Remove v22.06 for the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        sofa_branch: [master, v22.06]
+        sofa_branch: [master]
         python_version: ['3.8']
 
     steps:


### PR DESCRIPTION
API with SOFA v22.06 had been not compatible for a long time now