### PR TITLE
Add unit test for Mass multiple inheritance

### DIFF
--- a/bindings/Sofa/tests/Core/Mass.py
+++ b/bindings/Sofa/tests/Core/Mass.py
@@ -54,3 +54,8 @@ class Test(unittest.TestCase):
         self.assertEqual(M.ndim, 2)
         self.assertEqual(M.shape, (960, 960))
         self.assertEqual(M.nnz, 9480)
+
+    def test_mass_mstate(self):
+
+        root = self.simulate_beam("CompressedRowSparseMatrixMat3x3d")
+        self.assertNotEqual(root.mass.mstate, None)


### PR DESCRIPTION
The multiple inheritance property of Mass has been identified problematic in a previous pull request #325.

The test in this commit succeeds if Mass is defined with the label py::multiple_inheritance(). Otherwise it crashes.