### PR TITLE
[doc] Update SofaPython3 plugin documentation

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -4,7 +4,7 @@ General overview
 The SofaPython3 project brings python bindings for the `SOFA simulation framework <https://www.sofa-framework.org>`_.
 Thereby, it allows users to use most of the components and features found in SOFA directly into their python scripts.
 
-This project is composed of two modules: a *SOFA plugin* and several *python modules*.
+This project is composed of two modules: 1. a *SOFA plugin* in the *SofaPython3/Plugin/* repository and 2. several *python modules* in the *SofaPython3/bindings/* repository.
 
 1. The **SofaPython3 plugin** embeds a python interpreter and a SOFA scene loader. This plugin allows one to load a python
 script as the main simulation scene file. The scene loader will automatically detect the ".py", ".py3", ".py3scn" or
@@ -21,6 +21,7 @@ interpreter without requiring the load of the plugin.
 .. figure:: images/SP3_global_arch.png
     :alt: How SP3 fits in the SOFA usage pipeline
     :align: center
+    :width: 400
 
 Content
 -------

--- a/docs/sphinx/source/menu/SofaPlugin.rst
+++ b/docs/sphinx/source/menu/SofaPlugin.rst
@@ -551,7 +551,7 @@ One major advantage of coupling SOFA simulation and python is to access and proc
 Read access
 ^^^^^^^^^^^
 
-Let's consider the full scene introduced just `above in-tree <https://sofapython3.readthedocs.io/en/latest/menu/Compilation.html#full-scene>`_ and try to access data once the GUI is closed:
+Let's consider the full scene introduced just `above in-tree <https://sofapython3.readthedocs.io/en/latest/menu/Compilation.html#full-scene>`_ and try to access data using the ``.value`` acessor once the GUI is closed:
 
 
 .. code-block:: python
@@ -578,9 +578,54 @@ Note that:
 * Data which are vectors can be casted as numpy arrays
 
 
+
 Write access
 ^^^^^^^^^^^^
 
+In the same way, Data can be modified (write access) using the ``.value`` accessor. Here is an example (without GUI) computing 10 time steps, then setting the world gravity to zero and recomputing 10 time steps:
+
+
+.. code-block:: python
+
+
+	def main():
+
+        # Call the SOFA function to create the root node
+        root = Sofa.Core.Node("root")
+
+        # Call the createScene function, as runSofa does
+        createScene(root)
+
+        # Once defined, initialization of the scene graph
+        Sofa.Simulation.init(root)
+
+        # Run the simulation for 10 steps
+        for iteration in range(10):
+                Sofa.Simulation.animate(root, root.dt.value)
+        
+        # Print the position of the falling sphere
+        print(root.sphere.mstate.position.value)
+
+        # Increase the gravity
+        root.gravity.value = [0, 0, 0]
+
+        # Run the simulation for 10 steps MORE
+        for iteration in range(10):
+                Sofa.Simulation.animate(root, root.dt.value)
+
+        # Print the position of the falling sphere
+        print(root.sphere.mstate.position.value)
+
+
+The ``.value`` accessor works for simple Data structures such as a string, an integer, a floating-point numbers or a vector of these.
+
+For more complex Data such as Data related to the degrees of freedom (e.g. Coord/Deriv, VecCoord/VecDeriv), the ``.writeableArray()`` write accessor must be used. Let's consider a scene graph that would have a *ConstantForceField* named "CFF" in the sphere node, and that we would like to modify the Data "totalForce" (a Deriv defined in `ConstantForceField.h <https://github.com/sofa-framework/sofa/blob/master/Sofa/Component/MechanicalLoad/src/sofa/component/mechanicalload/ConstantForceField.h#L66>`_), we should then write something like:
+
+
+.. code-block:: python
+
+	with root.sphere.CFF.totalForce.writeableArray() as wa:
+        wa[0] += 0.01 # modify the first entry of the Deriv Data "totalForce"
 
 
 

--- a/docs/sphinx/source/menu/SofaPlugin.rst
+++ b/docs/sphinx/source/menu/SofaPlugin.rst
@@ -1,5 +1,3 @@
-`Text ici <websitepointcom>`_ 
-
 Using the plugin
 ================
 
@@ -547,13 +545,59 @@ Here is the entire code of the scene :
 Accessing data
 --------------
 
-One major advantage of coupling SOFA simulation and python is to access and process data before the simulation starts, while it is running and once the simulation ended.
+One major advantage of coupling SOFA simulation and python is to access and process data before the simulation starts, while it is running and once the simulation ended. All components in SOFA have so-called data. A data is a public attribute of a Component (C++ class) visible to the user in the SOFA user interface and any data can also be accessed though python.
+
+
+Read access
+^^^^^^^^^^^
+
+Let's consider the full scene introduced just `above in-tree <https://sofapython3.readthedocs.io/en/latest/menu/Compilation.html#full-scene>`_ and try to access data once the GUI is closed:
+
+
+.. code-block:: python
+
+	import Sofa
+	import Sofa.Gui
+
+
+	def main():
+        
+        ...
+
+        # Initialization of the scene will be done here
+        Sofa.Gui.GUIManager.MainLoop(root)
+        Sofa.Gui.GUIManager.closeGUI()
+
+        # Accessing and printing the final time of simulation
+        # "time" being the name of a Data available in all Nodes
+        finalTime = root.time.value
+        print(finalTime)
+
+Note that:
+* accessing the Data "time" doing ``root.time`` would only return the python pointer and not the value of the Data
+* Data which are vectors can be casted as numpy arrays
+
+
+Write access
+^^^^^^^^^^^^
+
+
 
 
 More simulation examples
 ------------------------
 
-Many `additional examples <https://github.com/sofa-framework/SofaPython3/tree/master/examples>`_ are available within the SofaPython3 plugin in the *examples/* folder. Do not hesitate to take a look and get inspiration!
+Many `additional examples <https://github.com/sofa-framework/SofaPython3/tree/master/examples>`_ are available within the SofaPython3 plugin in the *examples/* folder:
+
+* `basic.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/basic.py>`_ : basic scene with a rigid particle without a GUI
+* `basic-addGUI.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/basic-addGUI.py>`_ : same basic scene with a rigid particle with a GUI
+* `emptyController.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/emptyController.py>`_ : example displaying all possible functions available in python controllers
+* `access_matrix.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/access_matrix.py>`_ : example on how to access the system matrix and vector
+* `access_mass_matrix.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/access_mass_matrix.py>`_ : example on how to access the mass matrix
+* `access_stiffness_matrix.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/access_stiffness_matrix.py>`_ : example on how to access the stiffness matrix
+* `access_compliance_matrix.py <https://github.com/sofa-framework/SofaPython3/blob/master/examples/access_compliance_matrix.py>`_ : example on how to access the compliance matrix used in constraint problems
+
+Do not hesitate to take a look and get inspiration!
 
 
 Technical support

--- a/docs/sphinx/source/menu/SofaPlugin.rst
+++ b/docs/sphinx/source/menu/SofaPlugin.rst
@@ -1,3 +1,5 @@
+`Text ici <websitepointcom>`_ 
+
 Using the plugin
 ================
 
@@ -7,7 +9,7 @@ The SofaPython3 plugins allows you to embed a python3 interpreter into an exisin
 Prerequisites
 -------------
 
-If you downloaded and installed SOFA and its headers from the `SOFA website <https://www.sofa-framework.org/download/>`_, make sure to have python3.7 installed on your computed.
+If you downloaded and installed SOFA and its headers from the `SOFA website <https://www.sofa-framework.org/download/>`_, make sure to have python3.8 installed on your computed.
 
 .. content-tabs::
 
@@ -19,8 +21,8 @@ If you downloaded and installed SOFA and its headers from the `SOFA website <htt
 			.. code-block:: bash
 
 				sudo add-apt-repository ppa:deadsnakes/ppa
-				sudo apt install libpython3.7 python3.7 python3-pip
-				python3.7 -m pip install numpy
+				sudo apt install libpython3.8 python3.8 python3-pip
+				python3.8 -m pip install numpy
 
 			if you want to launch the runSofa:
 
@@ -36,15 +38,15 @@ If you downloaded and installed SOFA and its headers from the `SOFA website <htt
 
 			.. code-block:: bash
 
-				brew install python@3.7
-				export PATH="/usr/local/opt/python@3.7/bin/:$PATH"
+				brew install python@3.8
+				export PATH="/usr/local/opt/python@3.8/bin/:$PATH"
 
 			BigSur only:
 
 			.. code-block:: bash
 
 				pip3 install --upgrade pip
-				python3.7 -m pip install numpy
+				python3.8 -m pip install numpy
 
 			Catalina only:
 
@@ -56,17 +58,16 @@ If you downloaded and installed SOFA and its headers from the `SOFA website <htt
 	.. tab-container:: tab3
 		:title: Windows
 
-		Download and install `Python 3.7 64bit <https://www.python.org/ftp/python/3.7.9/python-3.7.9-amd64.exe>`_
+		Download and install `Python 3.8 64bit <https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe>`_
 
 
+Run a python script
+-------------------
 
 Within runSofa
---------------
-
+^^^^^^^^^^^^^^
 
 Using SofaPython3 in runSofa requires loading the SofaPython3 plugin in your runSofa environment.
-
-    
     
 
 * If you downloaded and installed SOFA and its headers from the `SOFA website <https://www.sofa-framework.org/download/>`_, or if you `compiled SofaPython3 in-tree <https://sofapython3.readthedocs.io/en/latest/menu/Compilation.html#in-tree-build>`_, you can load the SofaPython3 plugin using the PluginManager (in the GUI) or by auto-loading the plugin in runSofa: simply copy the file **plugin_list.conf.default** in *<SOFA_build>/lib*, and rename it **plugin_list.conf**, then add the line:
@@ -94,8 +95,7 @@ Using SofaPython3 in runSofa requires loading the SofaPython3 plugin in your run
 
 
 Within a python3 interpreter
-----------------------------
-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Before running your simulations, you must make sure to define the following environment variables:
 
@@ -121,7 +121,7 @@ Before running your simulations, you must make sure to define the following envi
 
 				export SOFA_ROOT=/path/to/SOFA_install
 				export PYTHONPATH=/path/to/SofaPython3/lib/python3/site-packages:$PYTHONPATH
-				export PATH="/usr/local/opt/python@3.7/bin/:$PATH"
+				export PATH="/usr/local/opt/python@3.8/bin/:$PATH"
 
 
 	.. tab-container:: tab3
@@ -152,12 +152,16 @@ The following code should cover most basic SOFA elements:
 	import Sofa.Core
 
 
-Simple example
---------------
+Create a simulation
+-------------------
 
-A scene in SOFA is an ordered tree of nodes representing objects (example of node: hand), with parent/child relationship (example of hand's child: finger). Each node has one or more components. Every node and component has a name and a few features. The main node at the top of the tree is usually called "rootNode" or "root".
+A scene in SOFA is an ordered tree of nodes representing objects (example of node: hand), with parent/child relationship (example of hand's child: finger). Each node has one or more components. Every node and component has a name and a few features. The main node at the top of the tree is usually called "rootNode" or "root". More about how to create a simulation scene can be found in the `SOFA online documentation <https://www.sofa-framework.org/community/doc/using-sofa/lexicography/>`_
 
-Just like with the legacy SofaPython plugin, SofaPython3 searches for a `createScene(arg0: Sofa.Core.Node) -> Sofa.Core.Node` method in the python script, to use as the entry point of the SOFA simulation, and taking a single parameter: the root Node.  Thus define this method:
+
+Within runSofa
+^^^^^^^^^^^^^^
+
+If a python script is loaded within the runSofa executable, make sure the SofaPython3 plugin is well loaded. When opening the python script, runSofa will search for the `createScene(arg0: Sofa.Core.Node) -> Sofa.Core.Node` method and it uses it as the entry point of the SOFA simulation, and taking a single parameter: the root Node.  Thus define this method:
 
 .. code-block:: python
 		
@@ -165,26 +169,91 @@ Just like with the legacy SofaPython plugin, SofaPython3 searches for a `createS
 		#Doesn't do anything yet
 		return rootNode
 
-You can then load a python scene in SOFA, but it doesn't do much. Let's enrich this scene!
 
-Create your first element
-^^^^^^^^^^^^^^^^^^^^^^^^^
-First things first, we import the module Sofa.Core, to have access to the functions we will need.
-Then, we add a grid, in order to see things more clearly. To do that, we simply need to add an object to the rootNode with the right properties :
+
+Within a python3 interpreter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the SofaPython3 plugin, it is also possible to execute a python script. However, to run a SOFA simulation from a python3 interpreter, the python environment must be aware of the SOFA python modules and their location. To do so, make sure to read the "`Within a python3 interpreter <https://sofapython3.readthedocs.io/en/latest/menu/SofaPlugin.html#within-a-python3-interpreter>`_" section.
+
+Within a python3 interpreter, your simulation requires more than only the ``createScene()`` function. Indeed, the python environment does not pre-generate a root node as the runSofa executable is. One must therefore create it and then call the ``createScene()`` function:
+
+
+.. code-block:: python
+
+	# Required import for SOFA within python
+	import Sofa
+
+
+	def main():
+		# Call the SOFA function to create the root node
+		root = Sofa.Core.Node("root")
+
+		# Call the createScene function, as runSofa does
+		createScene(root)
+
+		# Once defined, initialization of the scene graph
+		Sofa.Simulation.init(root)
+
+		# Run as many simulation steps (here 10 steps are computed)
+		for iteration in range(10):
+			Sofa.Simulation.animate(root, root.dt.value)
+
+
+	# Same createScene function as in the previous case
+	def createScene(rootNode):
+		#Doesn't do anything yet
+		return rootNode
+
+
+	# Function used only if this script is called from a python environment
+	if __name__ == '__main__':
+	    main()
+
+
+By structuring your scripts this way, you get the advantage to have a script loadable from both runSofa and a python3 interpreter. Note that the ``main()`` function runs 10 time steps without any graphical user interface and the script ends. In case you want to manage the simulation from the runSofa GUI, you can simply change the ``main()`` function as follows: 
+
+
+.. code-block:: python
+
+	def main():
+        # Call the SOFA function to create the root node
+        root = Sofa.Core.Node("root")
+
+        # Call the createScene function, as runSofa does
+        createScene(root)
+
+        # Once defined, initialization of the scene graph
+        Sofa.Simulation.init(root)
+
+        # Launch the GUI (qt or qglviewer)
+        Sofa.Gui.GUIManager.Init("myscene", "qglviewer")
+        Sofa.Gui.GUIManager.createGUI(root, __file__)
+        Sofa.Gui.GUIManager.SetDimension(1080, 800)
+
+        # Initialization of the scene will be done here
+        Sofa.Gui.GUIManager.MainLoop(root)
+        Sofa.Gui.GUIManager.closeGUI()
+
+
+So far, you can load this python scene, but it doesn't do much. Let's enrich this scene!
+
+
+Create your first object
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+We first propose to add a visual grid, in order to see things more clearly. To do that, we simply need to add an object to the rootNode with the right properties :
 
 .. code-block:: python 
 
-	import Sofa.Core
-
 	def createScene(rootNode):
-		rootNode.addObject("OglGrid", nbSubdiv=10, size=1000)
+		rootNode.addObject("VisualGrid", nbSubdiv=10, size=1000)
 
 Now, we create a new child node, in order to add the general configuration of the scene : required plugins (here SofaPython3) and other tools (like a system of axes).
 
 .. code-block:: python
 
 	confignode = rootNode.addChild("Config")
-	confignode.addObject('RequiredPlugin', name="SofaPython3", printLog=False)
 	confignode.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")
 
 
@@ -192,15 +261,15 @@ Finally, we add the sphere itself, which consists of two parts : the mechanical 
 
 .. code-block:: python
 
-    #Creating the sphere
-    sphere = rootNode.addChild("sphere")
-    sphere.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0., 0., 0.], rotation2=[0., 0., 0.], showObjectScale=50)
+    # Creating the falling sphere object
+	sphere = rootNode.addChild("sphere")
+	sphere.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0., 0., 0.], rotation2=[0., 0., 0.], showObjectScale=50)
 
-    #### visualization
-    sphereVisu = sphere.addChild("VisualModel")
-    sphereVisu.loader = sphereVisu.addObject('MeshObjLoader', name="loader", filename="mesh/ball.obj")
-    sphereVisu.addObject('OglModel', name="model", src="@loader", scale3d=[50]*3, color=[0., 1., 0.], updateNormals=False)
-    sphereVisu.addObject('RigidMapping')
+	#### Visualization subnode for the sphere
+	sphereVisu = sphere.addChild("VisualModel")
+	sphereVisu.loader = sphereVisu.addObject('MeshOBJLoader', name="loader", filename="mesh/ball.obj")
+	sphereVisu.addObject('OglModel', name="model", src="@loader", scale3d=[50]*3, color=[0., 1., 0.], updateNormals=False)
+	sphereVisu.addObject('RigidMapping')
 
 .. image:: ../images/exampleScene_step1.png
 	:alt: This is what you should see in Sofa at this stage
@@ -211,15 +280,15 @@ Finally, we add the sphere itself, which consists of two parts : the mechanical 
 Now, if you execute your scene, you can see a sphere, but it won't move if you click on the Animate button in SOFA. Let's change that!
 
 
-Add movements and forces
-^^^^^^^^^^^^^^^^^^^^^^^^
+Define physical properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A default gravity force is implemented on SOFA. Here we reset it, for learning purposes. We also define the time step of the simulation.
 
 .. code-block:: python
 	
-	rootNode.findData('gravity').value=[0.0,-9.81,0.0];
-	rootNode.findData('dt').value=0.01
+	rootNode.gravity=[0.0,-9.81,0.0]
+	rootNode.dt=0.01
 
 We add a mechanical model, so that all our futur elements will have the same total mass, volume and inertia matrix :
 
@@ -233,11 +302,13 @@ We add properties to the sphere. First, we add a mass, then an object called 'Un
 
 .. code-block:: python
 
+	# Creating the falling sphere object
+	sphere = rootNode.addChild("sphere")
+	sphere.addObject('EulerImplicitSolver', name='odesolver')
+	sphere.addObject('CGLinearSolver', name='Solver', iterations=25, tolerance=1e-05, threshold=1e-05)
+	sphere.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0., 0., 0.], rotation2=[0., 0., 0.], showObjectScale=50)
 	sphere.addObject('UniformMass', name="mass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
 	sphere.addObject('UncoupledConstraintCorrection')
-
-	sphere.addObject('EulerImplicitSolver', name='odesolver')
-	sphere.addObject('CGLinearSolver', name='Solver')
 
 .. image:: ../images/exampleScene_step2.gif
 	:alt: This is what you should see in Sofa at this stage
@@ -247,21 +318,34 @@ We add properties to the sphere. First, we add a mass, then an object called 'Un
 Now, if you click on the Animate button in SOFA, the sphere will fall.
 
 
-Add a second element 
-^^^^^^^^^^^^^^^^^^^^
+Add a second object 
+^^^^^^^^^^^^^^^^^^^
 
 Let's add a second element, a floor, to see how they interact :
 
 .. code-block:: python
 
-    floor = rootNode.addChild("floor")
-    floor.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0.0,-300.0,0.0], rotation2=[0., 0., 0.], showObjectScale=5.0)
-    floor.addObject('UniformMass', name="mass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
+    # Creating the floor object
+	floor = rootNode.addChild("floor")
 
-    floorVisu = floor.addChild("VisualModel")
-    floorVisu.loader = floorVisu.addObject('MeshObjLoader', name="loader", filename="mesh/floor.obj")
-    floorVisu.addObject('OglModel', name="model", src="@loader", scale3d=[5.0]*3, color=[1., 1., 0.], updateNormals=False)
-    floorVisu.addObject('RigidMapping')
+	floor.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0.0,-300.0,0.0], rotation2=[0., 0., 0.], showObjectScale=5.0)
+	floor.addObject('UniformMass', name="mass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
+
+	#### Collision subnode for the floor
+	floorCollis = floor.addChild('collision')
+	floorCollis.addObject('MeshOBJLoader', name="loader", filename="mesh/floor.obj", triangulate="true", scale=5.0)
+	floorCollis.addObject('MeshTopology', src="@loader")
+	floorCollis.addObject('MechanicalObject')
+	floorCollis.addObject('TriangleCollisionModel', moving=False, simulated=False)
+	floorCollis.addObject('LineCollisionModel', moving=False, simulated=False)
+	floorCollis.addObject('PointCollisionModel', moving=False, simulated=False)
+	floorCollis.addObject('RigidMapping')
+
+	#### Visualization subnode for the floor
+	floorVisu = floor.addChild("VisualModel")
+	floorVisu.loader = floorVisu.addObject('MeshOBJLoader', name="loader", filename="mesh/floor.obj")
+	floorVisu.addObject('OglModel', name="model", src="@loader", scale3d=[5.0]*3, color=[1., 1., 0.], updateNormals=False)
+	floorVisu.addObject('RigidMapping')
         
 .. image:: ../images/exampleScene_step3.gif
 	:alt: This is what you should see in Sofa at this stage
@@ -270,49 +354,53 @@ Let's add a second element, a floor, to see how they interact :
 
 A floor has now been added to the scene. It is a stationnary object, it won't move during the simulation. When you click on the Animate button, you can see that the sphere goes through the floor, as if there were nothing there. That is because there is no collision modeling in the scene yet.
 
-Add a collision model
-^^^^^^^^^^^^^^^^^^^^^
+
+Add a collision pipeline
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 We first add a collision model for the scene in general, that is stating how a contact between the objects is handled: here the objects must not be able to go through one another. Potential collisions are looked for within an alarmDistance radius from the objet. If a collision situation is detected, the collision model computes the behaviour of the objects, which are stopped at a ContactDistance from each other.
 
 .. code-block:: python
 
+	# Collision pipeline
 	rootNode.addObject('DefaultPipeline')
 	rootNode.addObject('FreeMotionAnimationLoop')
 	rootNode.addObject('GenericConstraintSolver', tolerance="1e-6", maxIterations="1000")
-	rootNode.addObject('BruteForceDetection')
-	rootNode.addObject('RuleBasedContactManager', responseParams="mu="+str(0.0), name='Response', response='FrictionContact')
+	rootNode.addObject('BruteForceBroadPhase')
+	rootNode.addObject('BVHNarrowPhase')
+	rootNode.addObject('RuleBasedContactManager', responseParams="mu="+str(0.0), name='Response', response='FrictionContactConstraint')
 	rootNode.addObject('LocalMinDistance', alarmDistance=10, contactDistance=5, angleCone=0.01)
+
 
 We add a new child node to the sphere, that will be in charge of processing the collision.
 
 .. code-block:: python
 
+	#### Collision subnode for the sphere
 	collision = sphere.addChild('collision')
-	collision.addObject('MeshObjLoader', name="loader", filename="mesh/ball.obj", triangulate="true", scale=45.0)
-
+	collision.addObject('MeshOBJLoader', name="loader", filename="mesh/ball.obj", triangulate="true", scale=45.0)
 	collision.addObject('MeshTopology', src="@loader")
 	collision.addObject('MechanicalObject')
-
 	collision.addObject('TriangleCollisionModel')
 	collision.addObject('LineCollisionModel')
 	collision.addObject('PointCollisionModel')
-
 	collision.addObject('RigidMapping')
+
 
 We do the same for the floor, but we also specify that the floor is a stationnary object that shouldn't move.
 
 .. code-block:: python
 
+	#### Collision subnode for the floor
 	floorCollis = floor.addChild('collision')
-	floorCollis.addObject('MeshObjLoader', name="loader", filename="mesh/floor.obj", triangulate="true", scale=5.0)
+	floorCollis.addObject('MeshOBJLoader', name="loader", filename="mesh/floor.obj", triangulate="true", scale=5.0)
 	floorCollis.addObject('MeshTopology', src="@loader")
 	floorCollis.addObject('MechanicalObject')
 	floorCollis.addObject('TriangleCollisionModel', moving=False, simulated=False)
 	floorCollis.addObject('LineCollisionModel', moving=False, simulated=False)
 	floorCollis.addObject('PointCollisionModel', moving=False, simulated=False)
-
 	floorCollis.addObject('RigidMapping')
+
 
 .. image:: ../images/exampleScene_step4.gif
 	:alt: This is what you should see in Sofa at this stage
@@ -324,155 +412,153 @@ Congratulations! You made your first SOFA scene in Python3!
 
 For more information on how to use the SOFA modules bindings in python, visit this page: :doc:`SofaModule`
 
+
+
+Full scene
+^^^^^^^^^^
 Here is the entire code of the scene :
 
 .. code-block:: python
 
-	import Sofa.Core
+	import Sofa
+	import Sofa.Gui
+
+
+	def main():
+        # Call the SOFA function to create the root node
+        root = Sofa.Core.Node("root")
+
+        # Call the createScene function, as runSofa does
+        createScene(root)
+
+        # Once defined, initialization of the scene graph
+        Sofa.Simulation.init(root)
+
+        # Launch the GUI (qt or qglviewer)
+        Sofa.Gui.GUIManager.Init("myscene", "qglviewer")
+        Sofa.Gui.GUIManager.createGUI(root, __file__)
+        Sofa.Gui.GUIManager.SetDimension(1080, 800)
+
+        # Initialization of the scene will be done here
+        Sofa.Gui.GUIManager.MainLoop(root)
+        Sofa.Gui.GUIManager.closeGUI()
+
 
 	def createScene(rootNode):
-		rootNode.addObject("OglGrid", nbSubdiv=10, size=1000)
 
-		rootNode.findData('gravity').value=[0.0,-981.0,0.0];
-		rootNode.findData('dt').value=0.01
+		rootNode.addObject("VisualGrid", nbSubdiv=10, size=1000)
 
+		# Define the root node properties
+		rootNode.gravity=[0.0,-9.81,0.0]
+		rootNode.dt=0.01
+
+		# Loading all required SOFA modules
 		confignode = rootNode.addChild("Config")
-		confignode.addObject('RequiredPlugin', name="SofaMiscCollision", printLog=False)
-		confignode.addObject('RequiredPlugin', name="SofaPython3", printLog=False)
+		confignode.addObject('RequiredPlugin', name="Sofa.Component.AnimationLoop", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Collision.Detection.Algorithm", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Collision.Detection.Intersection", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Collision.Geometry", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Collision.Response.Contact", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Constraint.Lagrangian.Correction", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Constraint.Lagrangian.Solver", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.IO.Mesh", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.LinearSolver.Iterative", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Mapping.NonLinear", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Mass", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.ODESolver.Backward", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.StateContainer", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Topology.Container.Constant", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.Component.Visual", printLog=False)
+        confignode.addObject('RequiredPlugin', name="Sofa.GL.Component.Rendering3D", printLog=False)
 		confignode.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")
 
 
-	 	#Collision function
-
+	 	# Collision pipeline
 		rootNode.addObject('DefaultPipeline')
 		rootNode.addObject('FreeMotionAnimationLoop')
 		rootNode.addObject('GenericConstraintSolver', tolerance="1e-6", maxIterations="1000")
-		rootNode.addObject('BruteForceDetection')
-		rootNode.addObject('RuleBasedContactManager', responseParams="mu="+str(0.0), name='Response', response='FrictionContact')
+		rootNode.addObject('BruteForceBroadPhase')
+		rootNode.addObject('BVHNarrowPhase')
+		rootNode.addObject('RuleBasedContactManager', responseParams="mu="+str(0.0), name='Response', response='FrictionContactConstraint')
 		rootNode.addObject('LocalMinDistance', alarmDistance=10, contactDistance=5, angleCone=0.01)
 
-		### Mechanical model
 
 		totalMass = 1.0
 		volume = 1.0
 		inertiaMatrix=[1., 0., 0., 0., 1., 0., 0., 0., 1.]
+		
+		# Creating the falling sphere object
+		sphere = rootNode.addChild("sphere")
+		sphere.addObject('EulerImplicitSolver', name='odesolver')
+		sphere.addObject('CGLinearSolver', name='Solver', iterations=25, tolerance=1e-05, threshold=1e-05)
+		sphere.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0., 0., 0.], rotation2=[0., 0., 0.], showObjectScale=50)
+		sphere.addObject('UniformMass', name="mass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
+		sphere.addObject('UncoupledConstraintCorrection')
 
-		#Creating the floor
+		#### Collision subnode for the sphere
+		collision = sphere.addChild('collision')
+		collision.addObject('MeshOBJLoader', name="loader", filename="mesh/ball.obj", triangulate="true", scale=45.0)
+		collision.addObject('MeshTopology', src="@loader")
+		collision.addObject('MechanicalObject')
+		collision.addObject('TriangleCollisionModel')
+		collision.addObject('LineCollisionModel')
+		collision.addObject('PointCollisionModel')
+		collision.addObject('RigidMapping')
+
+		#### Visualization subnode for the sphere
+		sphereVisu = sphere.addChild("VisualModel")
+		sphereVisu.loader = sphereVisu.addObject('MeshOBJLoader', name="loader", filename="mesh/ball.obj")
+		sphereVisu.addObject('OglModel', name="model", src="@loader", scale3d=[50]*3, color=[0., 1., 0.], updateNormals=False)
+		sphereVisu.addObject('RigidMapping')
+
+
+		# Creating the floor object
 		floor = rootNode.addChild("floor")
 
 		floor.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0.0,-300.0,0.0], rotation2=[0., 0., 0.], showObjectScale=5.0)
-
 		floor.addObject('UniformMass', name="mass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
+
+		#### Collision subnode for the floor
 		floorCollis = floor.addChild('collision')
-		floorCollis.addObject('MeshObjLoader', name="loader", filename="mesh/floor.obj", triangulate="true", scale=5.0)
+		floorCollis.addObject('MeshOBJLoader', name="loader", filename="mesh/floor.obj", triangulate="true", scale=5.0)
 		floorCollis.addObject('MeshTopology', src="@loader")
 		floorCollis.addObject('MechanicalObject')
 		floorCollis.addObject('TriangleCollisionModel', moving=False, simulated=False)
 		floorCollis.addObject('LineCollisionModel', moving=False, simulated=False)
 		floorCollis.addObject('PointCollisionModel', moving=False, simulated=False)
-
 		floorCollis.addObject('RigidMapping')
 
-		#### visualization
+		#### Visualization subnode for the floor
 		floorVisu = floor.addChild("VisualModel")
-		floorVisu.loader = floorVisu.addObject('MeshObjLoader', name="loader", filename="mesh/floor.obj")
+		floorVisu.loader = floorVisu.addObject('MeshOBJLoader', name="loader", filename="mesh/floor.obj")
 		floorVisu.addObject('OglModel', name="model", src="@loader", scale3d=[5.0]*3, color=[1., 1., 0.], updateNormals=False)
 		floorVisu.addObject('RigidMapping')
 
-		#Creating the sphere
-		sphere = rootNode.addChild("sphere")
-		sphere.addObject('MechanicalObject', name="mstate", template="Rigid3", translation2=[0., 0., 0.], rotation2=[0., 0., 0.], showObjectScale=50)
-		sphere.addObject('UniformMass', name="mass", vertexMass=[totalMass, volume, inertiaMatrix[:]])
-		sphere.addObject('UncoupledConstraintCorrection')
-
-		sphere.addObject('EulerImplicitSolver', name='odesolver')
-		sphere.addObject('CGLinearSolver', name='Solver')
-
-		collision = sphere.addChild('collision')
-		collision.addObject('MeshObjLoader', name="loader", filename="mesh/ball.obj", triangulate="true", scale=45.0)
-
-		collision.addObject('MeshTopology', src="@loader")
-		collision.addObject('MechanicalObject')
-
-		collision.addObject('TriangleCollisionModel')
-		collision.addObject('LineCollisionModel')
-		collision.addObject('PointCollisionModel')
-
-		collision.addObject('RigidMapping')
-
-		#### visualization
-		sphereVisu = sphere.addChild("VisualModel")
-		sphereVisu.loader = sphereVisu.addObject('MeshObjLoader', name="loader", filename="mesh/ball.obj")
-		sphereVisu.addObject('OglModel', name="model", src="@loader", scale3d=[50]*3, color=[0., 1., 0.], updateNormals=False)
-		sphereVisu.addObject('RigidMapping')
 
 		return rootNode
 
 
-For SofaPython2 users
----------------------
-
-If you were using the previous SofaPython plugin (2.7) and that you are willing to update your scenes for SofaPython3, this section is for you. The new SofaPython3 required a lot of development efforts, however, the way of writing a scene in a python script remains very similar. This step should be rather smooth:
-
-* Now you have the possibility to select which part of SOFA to import depending on your needs. See the existing `SOFA modules <https://sofapython3.readthedocs.io/en/latest/menu/SofaModule.html>`_. For example:
-.. code-block:: python
-
-    import Sofa.Helper
-    import Sofa.Core
-    import Sofa.Components
-    ...
-
-* To load SOFA plugins, you will have to import them:
-.. code-block:: python
-
-    import SofaRuntime
-    SofaRuntime.importPlugin("MyAwesomeComponent")
-
-
-* To be launchable from both runSofa and a python environment, make sure that your scene structure follows:
-
-.. code-block:: python
-
-	# Required import for python
-	import Sofa.Core
-	import Sofa.Simulation
-	import SofaRuntime
-
-
-	# Function creating the scene and describing the graph (with nodes and components) before it is initialized
-	def createScene(root):
-		return root
-
-
-	#Main function ONLY called if this script is called from a python environment
-	def main():
-
-		# Make sure to load all SOFA libraries and plugins
-		SofaRuntime.importPlugin("Sofa.Component.StateContainer")
-
-		# Generate the root node
-		root = Sofa.Core.Node("root")
-
-		# Call the above function to create the scene graph
-		createScene(root)
-
-		# Once defined, initialization of the scene graph
-		Sofa.Simulation.init(root)
-
-		# Run the simulation for 10 steps
-		for iteration in range(10):
-			Sofa.Simulation.animate(root, root.dt.value)
-
-
-	# Function used only if this script is called from a python environment, triggers the main()
+	# Function used only if this script is called from a python environment
 	if __name__ == '__main__':
 	    main()
 
 
-* In the ``createScene()`` function, creating an object or a node in the scene changed as follows:
 
-  * Objects are now added using the **addObject** function (instead of createObject):
-  ``createObject('Object', name='myObjectName', data=dataValue)`` becomes ``addObject('Object', name='myObjectName', data=dataValue )``
+Accessing data
+--------------
 
-  * Nodes are now added using the **addChild** function (instead of createChild):
-  ``parentNode.createChild("childNodeName")`` becomes ``parentNode.addChild("childNodeName")``
+One major advantage of coupling SOFA simulation and python is to access and process data before the simulation starts, while it is running and once the simulation ended.
+
+
+More simulation examples
+------------------------
+
+Many `additional examples <https://github.com/sofa-framework/SofaPython3/tree/master/examples>`_ are available within the SofaPython3 plugin in the *examples/* folder. Do not hesitate to take a look and get inspiration!
+
+
+Technical support
+-----------------
+
+To freely get help from the community, please do not hesitate to join the `SofaPython3 GitHub forum <https://github.com/sofa-framework/sofapython3/discussions>`_ and post there any question related to SofaPython3.
+
+To quickly level up on SOFA, never hesitate to request `SOFA training sessions <https://www.sofa-framework.org/sofa-events/sofa-training-sessions/>`_.


### PR DESCRIPTION
This PR proposes two main changes in the doc:
- update the required python version (3.7 -> 3.8)
- improve the source files of the '*Using the plugin*' section describing the python API and script format to use SOFA within python

The actual files read by readthedoc are not updated and we should rethink about the doc generation.

@marques-bruno : sorry to poke you but I tried to follow the [instructions to build the readthedoc files](https://github.com/sofa-framework/SofaPython3/tree/master/docs#2-generating-the-stubs) but it failed.
The command : `pybind11-stubgen -o sphinx-stubs --no-setup-py --ignore-invalid=signature --root-module-suffix="" Sofa`

gives the following error:
```
[ERROR]   [PythonScript] TypeError: 'Sofa.Components.Creator' object is not iterable
  File "/home/hugo/.local/bin/pybind11-stubgen", line 8, in <module>
    sys.exit(main())
  File "/home/hugo/.local/lib/python3.8/site-packages/pybind11_stubgen/__init__.py", line 1108, in main
    _module.parse()
  File "/home/hugo/.local/lib/python3.8/site-packages/pybind11_stubgen/__init__.py", line 879, in parse
    x.parse()
  File "/home/hugo/.local/lib/python3.8/site-packages/pybind11_stubgen/__init__.py", line 847, in parse
    for name, member in inspect.getmembers(self.module):
  File "/usr/lib/python3.8/inspect.py", line 339, in getmembers
    for base in object.__bases__:
```