### PR TITLE
[Bindings.SofaGui] Fix compilation without compat layer

### DIFF
--- a/bindings/SofaGui/Bindings.SofaGuiConfig.cmake.in
+++ b/bindings/SofaGui/Bindings.SofaGuiConfig.cmake.in
@@ -5,7 +5,6 @@
 
 find_package(SofaPython3 QUIET REQUIRED COMPONENTS Plugin Bindings.Sofa)
 
-find_package(Sofa.GL QUIET REQUIRED)
 find_package(Sofa.Core QUIET REQUIRED)
 find_package(Sofa.Gui.Common QUIET REQUIRED)
 

--- a/bindings/SofaGui/Bindings.SofaGuiConfig.cmake.in
+++ b/bindings/SofaGui/Bindings.SofaGuiConfig.cmake.in
@@ -7,7 +7,19 @@ find_package(SofaPython3 QUIET REQUIRED COMPONENTS Plugin Bindings.Sofa)
 
 find_package(Sofa.GL QUIET REQUIRED)
 find_package(Sofa.Core QUIET REQUIRED)
-find_package(SofaGui QUIET REQUIRED)
+find_package(Sofa.Gui.Common QUIET REQUIRED)
+
+if(Sofa.GUI.Batch_FOUND)
+    find_package(Sofa.GUI.Batch QUIET REQUIRED)
+endif()
+
+if(Sofa.GUI.Qt_FOUND)
+    find_package(Sofa.GUI.Qt QUIET REQUIRED)
+endif()
+
+if(Sofa.GUI.HeadlessRecorder_FOUND)
+    find_package(Sofa.GUI.HeadlessRecorder QUIET REQUIRED)
+endif()
 
 # If we are importing this config file and the target is not yet there this is indicating that
 # target is an imported one. So we include it

--- a/bindings/SofaGui/CMakeLists.txt
+++ b/bindings/SofaGui/CMakeLists.txt
@@ -13,7 +13,6 @@ set(HEADER_FILES
 )
 
 sofa_find_package(Sofa.Core REQUIRED)
-sofa_find_package(Sofa.GL REQUIRED)
 sofa_find_package(Sofa.GUI.Common REQUIRED) # to get the GUI mechanism
 
 sofa_find_package(Sofa.GUI.Batch QUIET)
@@ -41,7 +40,7 @@ SP3_add_python_module(
     DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      Sofa.Core Sofa.GL Sofa.GUI.Common SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core ${SUPPORTED_GUIS}
+    DEPENDS      Sofa.Core Sofa.GUI.Common SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core ${SUPPORTED_GUIS}
 )
 
 sofa_create_component_in_package_with_targets(

--- a/bindings/SofaGui/CMakeLists.txt
+++ b/bindings/SofaGui/CMakeLists.txt
@@ -12,24 +12,27 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SofaGui/Binding_GUIManager.h
 )
 
-set(DEPENDS_LIST Sofa.Core Sofa.GL Sofa.GUI.Common SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core)
-
 sofa_find_package(Sofa.Core REQUIRED)
 sofa_find_package(Sofa.GL REQUIRED)
-
 sofa_find_package(Sofa.GUI.Common REQUIRED) # to get the GUI mechanism
 
 sofa_find_package(Sofa.GUI.Batch QUIET)
 if(Sofa.GUI.Batch_FOUND)
-     list(APPEND DEPENDS_LIST Sofa.GUI.Batch)
+     list(APPEND SUPPORTED_GUIS Sofa.GUI.Batch)
 endif()
 sofa_find_package(Sofa.GUI.Qt QUIET)
 if(Sofa.GUI.Qt_FOUND)
-     list(APPEND DEPENDS_LIST Sofa.GUI.Qt)
+     list(APPEND SUPPORTED_GUIS Sofa.GUI.Qt)
 endif()
 sofa_find_package(Sofa.GUI.HeadlessRecorder QUIET)
 if(Sofa.GUI.HeadlessRecorder_FOUND)
-     list(APPEND DEPENDS_LIST Sofa.GUI.HeadlessRecorder)
+     list(APPEND SUPPORTED_GUIS Sofa.GUI.HeadlessRecorder)
+endif()
+
+if(SUPPORTED_GUIS)
+     message(STATUS "SofaPython3: Bindings.SofaGui will support: ${SUPPORTED_GUIS} .")
+else()
+     message(WARNING "SofaPython3: No GUIs detected.")
 endif()
 
 SP3_add_python_module(
@@ -38,7 +41,7 @@ SP3_add_python_module(
     DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      ${DEPENDS_LIST}
+    DEPENDS      Sofa.Core Sofa.GL Sofa.GUI.Common SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core ${SUPPORTED_GUIS}
 )
 
 sofa_create_component_in_package_with_targets(

--- a/bindings/SofaGui/CMakeLists.txt
+++ b/bindings/SofaGui/CMakeLists.txt
@@ -12,9 +12,25 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SofaGui/Binding_GUIManager.h
 )
 
+set(DEPENDS_LIST Sofa.Core Sofa.GL Sofa.GUI.Common SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core)
+
 sofa_find_package(Sofa.Core REQUIRED)
-sofa_find_package(SofaGui REQUIRED)
 sofa_find_package(Sofa.GL REQUIRED)
+
+sofa_find_package(Sofa.GUI.Common REQUIRED) # to get the GUI mechanism
+
+sofa_find_package(Sofa.GUI.Batch QUIET)
+if(Sofa.GUI.Batch_FOUND)
+     list(APPEND DEPENDS_LIST Sofa.GUI.Batch)
+endif()
+sofa_find_package(Sofa.GUI.Qt QUIET)
+if(Sofa.GUI.Qt_FOUND)
+     list(APPEND DEPENDS_LIST Sofa.GUI.Qt)
+endif()
+sofa_find_package(Sofa.GUI.HeadlessRecorder QUIET)
+if(Sofa.GUI.HeadlessRecorder_FOUND)
+     list(APPEND DEPENDS_LIST Sofa.GUI.HeadlessRecorder)
+endif()
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
@@ -22,7 +38,7 @@ SP3_add_python_module(
     DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      Sofa.Core SofaGui SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+    DEPENDS      ${DEPENDS_LIST}
 )
 
 sofa_create_component_in_package_with_targets(

--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
@@ -96,7 +96,7 @@ PYBIND11_MODULE(Gui, m) {
     }
 #endif // HAS_GUI_QT
 
-    // forcefullly link libraries at compile-time
+// forcefullly link libraries at compile-time
 #ifdef HAS_GUI_BATCH
     sofa::gui::batch::init();
 #endif


### PR DESCRIPTION
due to the fact that SofaGui is only included with the compat layer now.
(due to https://github.com/sofa-framework/sofa/pull/3550)

The cmake file will now explicitly find/add the different guis now (instead of implicitly with the  former SofaGui)