### PR TITLE
Extract testing features from the main library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,9 @@ add_subdirectory(Plugin)
 add_subdirectory(bindings)
 add_subdirectory(examples)
 add_subdirectory(docs)
+if (SP3_BUILD_TEST)
+    add_subdirectory(testing)
+endif()
 
 SP3_add_python_package(
     SOURCE_DIRECTORY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ add_subdirectory(bindings)
 add_subdirectory(examples)
 add_subdirectory(docs)
 if (SP3_BUILD_TEST)
-    add_subdirectory(testing)
+    add_subdirectory(Testing)
 endif()
 
 SP3_add_python_package(

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -26,22 +26,6 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Prefab.cpp
 )
 
-if(SP3_BUILD_TEST)
-    find_package(Sofa.Testing REQUIRED)
-    if(Sofa.Testing_FOUND)
-        list(APPEND HEADER_FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonTest.h
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonTestExtractor.h
-        )
-        list(APPEND SOURCE_FILES
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonTest.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/PythonTestExtractor.cpp
-        )
-    else()
-        message(WARNING "Sofa.Testing has not been found, SofaPython3 tests cannot be built.")
-    endif(Sofa.Testing_FOUND)
-endif(SP3_BUILD_TEST)
-
 find_package(pybind11 CONFIG REQUIRED)
 sofa_find_package(Sofa.Simulation.Graph REQUIRED)
 
@@ -52,10 +36,6 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_SOFAPYTHON3")
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Simulation.Graph)
 target_link_libraries(${PROJECT_NAME} PUBLIC pybind11::module pybind11::embed)
-
-if(SP3_BUILD_TEST AND Sofa.Testing_FOUND)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing)
-endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME SofaPython3)
 

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing SofaPython3::Plugin)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_SOFAPYTHON3")
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Testing)
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(SofaPython3Testing VERSION 1.0)
+
+find_package(Sofa.Testing REQUIRED)
+
+set(HEADER_FILES
+    src/SofaPython3Testing/config.h.in
+    src/SofaPython3Testing/PythonTest.h
+    src/SofaPython3Testing/PythonTestExtractor.h
+)
+
+set(SOURCE_FILES
+    src/SofaPython3Testing/init.cpp
+    src/SofaPython3Testing/PythonTest.cpp
+    src/SofaPython3Testing/PythonTestExtractor.cpp
+)
+
+add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.Testing SofaPython3::Plugin)
+target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_SOFAPYTHON3")
+
+sofa_create_package_with_targets(
+    PACKAGE_NAME ${PROJECT_NAME}
+    PACKAGE_VERSION ${SofaPython3_VERSION}
+    TARGETS ${PROJECT_NAME} AUTO_SET_TARGET_PROPERTIES
+    INCLUDE_SOURCE_DIR "src"
+    INCLUDE_INSTALL_DIR "${PROJECT_NAME}"
+)

--- a/Testing/SofaPython3TestingConfig.cmake.in
+++ b/Testing/SofaPython3TestingConfig.cmake.in
@@ -1,0 +1,17 @@
+# CMake package configuration file for @PROJECT_NAME@
+
+@PACKAGE_GUARD@
+@PACKAGE_INIT@
+
+set(SP3_BUILD_TEST @SP3_BUILD_TEST@)
+
+find_package(Sofa.Testing QUIET REQUIRED)
+
+# If we are importing this config file and the target is not yet there this is indicating that
+# target is an imported one. So we include it
+if(NOT TARGET @PROJECT_NAME@)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+endif()
+
+# Check that the component/target is there.
+check_required_components(@PROJECT_NAME@)

--- a/Testing/src/SofaPython3Testing/PythonTest.cpp
+++ b/Testing/src/SofaPython3Testing/PythonTest.cpp
@@ -38,9 +38,9 @@ namespace simpleapi=sofa::simpleapi;
 #include <sofa/helper/system/SetDirectory.h>
 using sofa::helper::system::SetDirectory;
 
-#include <SofaPython3/PythonTestExtractor.h>
+#include <SofaPython3Testing/PythonTestExtractor.h>
 #include <numeric>
-#include "PythonEnvironment.h"
+#include <SofaPython3/PythonEnvironment.h>
 #include "PythonTest.h"
 
 MSG_REGISTER_CLASS(sofapython3::PythonTest, "SofaPython3::PythonTest")
@@ -49,7 +49,7 @@ namespace sofapython3
 {
 
 /// This function is used by gtest to print the content of the struct in a meaninfull way
-void SOFAPYTHON3_API PrintTo(const sofapython3::PythonTestData& d, ::std::ostream *os)
+void PrintTo(const sofapython3::PythonTestData& d, ::std::ostream *os)
 {
     (*os) << d.filepath  ;
     (*os) << " with args {" ;

--- a/Testing/src/SofaPython3Testing/PythonTest.h
+++ b/Testing/src/SofaPython3Testing/PythonTest.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <string>
-#include <SofaPython3/config.h>
+#include <SofaPython3Testing/config.h>
 #include <sofa/testing/BaseTest.h>
 
 #include <filesystem>
@@ -33,7 +33,7 @@ namespace sofapython3
 using sofa::testing::BaseTest;
 
 /// a Python_test is defined by a python filepath and optional arguments
-struct SOFAPYTHON3_API PythonTestData
+struct SOFAPYTHON3_TESTING_API PythonTestData
 {
     PythonTestData (std::string filepath, std::string testgroup, std::vector<std::string> arguments)
             : filepath(std::move(filepath)), arguments(std::move(arguments)), testgroup{std::move(testgroup)} {}
@@ -48,10 +48,10 @@ struct SOFAPYTHON3_API PythonTestData
 ///        test.all_tests/2, where GetParam() = /path/to/file.py with args {1,2,3}
 /// instead of the defautl googletest printer that output things like the following:
 ///        test.all_tests/2, where GetParam() = 56-byte object <10-48 EC-37 18-56 00-00 67-00-00-00>
-void SOFAPYTHON3_API PrintTo(const PythonTestData& d, ::std::ostream* os);
+void SOFAPYTHON3_TESTING_API PrintTo(const PythonTestData& d, ::std::ostream* os);
 
 /// A test written in python (but not as a sofa class to perform unitary testing on python functions)
-class SOFAPYTHON3_API PythonTest : public BaseTest,
+class SOFAPYTHON3_TESTING_API PythonTest : public BaseTest,
         public ::testing::WithParamInterface<PythonTestData>
 {
 public:
@@ -67,7 +67,7 @@ public:
 
     /// This function is called by gtest to generate the test from the filename. This is nice
     /// As this allows to do mytest --gtest_filter=*MySomething*
-    static std::string getTestName(const testing::TestParamInfo<PythonTestData>& p)
+    static std::string getTestName(const ::testing::TestParamInfo<PythonTestData>& p)
     {
         if(p.param.arguments.size()==0)
             return  std::to_string(p.index)+"_"+p.param.testgroup+path(p.param.filepath).stem().string();

--- a/Testing/src/SofaPython3Testing/PythonTestExtractor.cpp
+++ b/Testing/src/SofaPython3Testing/PythonTestExtractor.cpp
@@ -18,7 +18,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include <SofaPython3/PythonTestExtractor.h>
+#include <SofaPython3Testing/PythonTestExtractor.h>
 #include <SofaPython3/PythonEnvironment.h>
 
 #include <sofa/helper/logging/Messaging.h>

--- a/Testing/src/SofaPython3Testing/PythonTestExtractor.h
+++ b/Testing/src/SofaPython3Testing/PythonTestExtractor.h
@@ -17,9 +17,9 @@
 *******************************************************************************
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
-#include <SofaPython3/config.h>
-#include <SofaPython3/PythonTest.h>
+#pragma once
+#include <SofaPython3Testing/config.h>
+#include <SofaPython3Testing/PythonTest.h>
 
 #include <utility>
 #include <pybind11/pybind11.h>
@@ -32,7 +32,7 @@ namespace sofapython3
 /**
  * Utility class that loads up python files and extract the unittest.
  */
-class SOFAPYTHON3_API PythonTestExtractor
+class SOFAPYTHON3_TESTING_API PythonTestExtractor
 {
 public:
     /**

--- a/Testing/src/SofaPython3Testing/config.h.in
+++ b/Testing/src/SofaPython3Testing/config.h.in
@@ -17,38 +17,17 @@
 *******************************************************************************
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#pragma once
+#include <SofaPython3/config.h>
 
-#include <vector>
+#ifdef SOFA_BUILD_SOFAPYTHON3
+#  define SOFAPYTHON3_TESTING_API PYBIND11_EXPORT
+#else
+#  define SOFAPYTHON3_TESTING_API SOFA_IMPORT_DYNAMIC_LIBRARY
+#endif
 
-#include <SofaPython3Testing/PythonTest.h>
-#include <sofa/helper/Utils.h>
-#include <SofaPython3Testing/PythonTestExtractor.h>
-
-using sofapython3::PythonTest ;
-using sofapython3::PythonTestExtractor ;
-using sofapython3::PrintTo ;
-using std::string;
-
-namespace
+namespace sofapython3::testing
 {
-
-  class PythonModule_SofaTypes_test : public PythonTestExtractor
-  {
-  public:
-    PythonModule_SofaTypes_test()
-    {
-        const std::string executable_directory = sofa::helper::Utils::getExecutableDirectory();
-        addTestDirectory(executable_directory+"/Bindings.SofaTypes.Tests.d/pyfiles", "SofaTypes_");
-    }
-  } python_tests;
-
-  /// run test list using the custom name function getTestName.
-  /// this allows to do gtest_filter=*FileName*
-  INSTANTIATE_TEST_SUITE_P(Batch,
-			  PythonTest,
-              ::testing::ValuesIn(python_tests.extract()),
-              PythonTest::getTestName);
-
-  TEST_P(PythonTest, all_tests) { run(GetParam()); }
-
-}
+    constexpr const char* MODULE_NAME = "@PROJECT_NAME@";
+    constexpr const char* MODULE_VERSION = "@PROJECT_VERSION@";
+} // namespace sofapython3::testing

--- a/Testing/src/SofaPython3Testing/init.cpp
+++ b/Testing/src/SofaPython3Testing/init.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
-*                              SofaPython3 plugin                             *
-*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *
@@ -15,40 +15,42 @@
 * You should have received a copy of the GNU Lesser General Public License    *
 * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
 *******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-
-#include <vector>
-
-#include <SofaPython3Testing/PythonTest.h>
-#include <sofa/helper/Utils.h>
-#include <SofaPython3Testing/PythonTestExtractor.h>
-
-using sofapython3::PythonTest ;
-using sofapython3::PythonTestExtractor ;
-using sofapython3::PrintTo ;
-using std::string;
-
-namespace
+#include <SofaPython3Testing/config.h>
+namespace sofapython3::testing
 {
 
-  class PythonModule_SofaTypes_test : public PythonTestExtractor
-  {
-  public:
-    PythonModule_SofaTypes_test()
+extern "C" {
+    SOFA_EXPORT_DYNAMIC_LIBRARY void initExternalModule();
+    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleName();
+    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleVersion();
+    SOFA_EXPORT_DYNAMIC_LIBRARY const char* getModuleComponentList();
+}
+
+void initExternalModule()
+{
+    static bool first = true;
+    if (first)
     {
-        const std::string executable_directory = sofa::helper::Utils::getExecutableDirectory();
-        addTestDirectory(executable_directory+"/Bindings.SofaTypes.Tests.d/pyfiles", "SofaTypes_");
+        first = false;
     }
-  } python_tests;
+}
 
-  /// run test list using the custom name function getTestName.
-  /// this allows to do gtest_filter=*FileName*
-  INSTANTIATE_TEST_SUITE_P(Batch,
-			  PythonTest,
-              ::testing::ValuesIn(python_tests.extract()),
-              PythonTest::getTestName);
+const char* getModuleName()
+{
+    return MODULE_NAME;
+}
 
-  TEST_P(PythonTest, all_tests) { run(GetParam()); }
+const char* getModuleVersion()
+{
+    return MODULE_VERSION;
+}
 
+const char* getModuleComponentList()
+{
+    return {};
+}
 }

--- a/bindings/Modules/tests/CMakeLists.txt
+++ b/bindings/Modules/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Sofa.Testing REQUIRED)
 
 enable_testing()
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3::Plugin)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3Testing)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "Bindings/Tests")
 

--- a/bindings/Modules/tests/main.cpp
+++ b/bindings/Modules/tests/main.cpp
@@ -18,8 +18,8 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include <SofaPython3/PythonTest.h>
-#include <SofaPython3/PythonTestExtractor.h>
+#include <SofaPython3Testing/PythonTest.h>
+#include <SofaPython3Testing/PythonTestExtractor.h>
 #include <sofa/helper/Utils.h>
 
 #include <sofa/helper/logging/Messaging.h>

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ find_package(Sofa.Testing REQUIRED)
 
 enable_testing()
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3::Plugin)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3Testing)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "Bindings/Tests")
 

--- a/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
+++ b/bindings/Sofa/tests/PythonModule_Sofa_test.cpp
@@ -20,9 +20,9 @@
 
 #include <vector>
 
-#include <SofaPython3/PythonTest.h>
+#include <SofaPython3Testing/PythonTest.h>
 #include <sofa/helper/Utils.h>
-#include <SofaPython3/PythonTestExtractor.h>
+#include <SofaPython3Testing/PythonTestExtractor.h>
 
 using sofapython3::PythonTest ;
 using sofapython3::PythonTestExtractor ;

--- a/bindings/SofaRuntime/tests/CMakeLists.txt
+++ b/bindings/SofaRuntime/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Sofa.Testing REQUIRED)
 
 enable_testing()
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3::Plugin)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3Testing)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "Bindings/Tests")
 

--- a/bindings/SofaRuntime/tests/PythonModule_SofaRuntime_test.cpp
+++ b/bindings/SofaRuntime/tests/PythonModule_SofaRuntime_test.cpp
@@ -20,9 +20,9 @@
 
 #include <vector>
 
-#include <SofaPython3/PythonTest.h>
+#include <SofaPython3Testing/PythonTest.h>
 #include <sofa/helper/Utils.h>
-#include <SofaPython3/PythonTestExtractor.h>
+#include <SofaPython3Testing/PythonTestExtractor.h>
 
 using sofapython3::PythonTest ;
 using sofapython3::PythonTestExtractor ;

--- a/bindings/SofaTypes/tests/CMakeLists.txt
+++ b/bindings/SofaTypes/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Sofa.Testing REQUIRED)
 
 enable_testing()
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3::Plugin)
+target_link_libraries(${PROJECT_NAME} Sofa.Testing SofaPython3Testing)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/pyfiles/\"")
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "Bindings/Tests")
 


### PR DESCRIPTION
To me, it is weird that the testing features were included in the SofaPython3 lib. It was optionally compiled (based on the value of `SP3_BUILD_TEST`), and it comes with all its dependencies (`Sofa.Testing`, gtest etc). That's why I created a dedicated module