### PR TITLE
Add syntaxForAddingRequiredPlugin function

### DIFF
--- a/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
@@ -74,6 +74,18 @@ void SceneLoaderPY3::getExtensionList(ExtensionList* list)
     list->push_back("py");
 }
 
+bool SceneLoaderPY3::syntaxForAddingRequiredPlugin(const std::string& pluginName,
+                                                   const std::vector<std::string>& listComponents, std::ostream& ss, sofa::simulation::Node* nodeWhereAdded)
+{
+    ss << nodeWhereAdded->getName() << ".addObject('RequiredPlugin', name='" << pluginName << "')";
+    if (!listComponents.empty())
+    {
+        ss <<  " # Needed to use components [" << sofa::helper::join(listComponents, ',');
+    }
+    ss << "]" << msgendl;
+    return true;
+}
+
 sofa::simulation::Node::SPtr SceneLoaderPY3::doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs)
 {
     sofa::simulation::Node::SPtr root = sofa::simulation::Node::create("root");
@@ -100,7 +112,7 @@ void SceneLoaderPY3::loadSceneWithArguments(const char *filename,
 
         if(!py::hasattr(module, "createScene"))
         {
-            msg_error() << "Missing createScene function";
+            msg_error("SofaPython3") << "Missing createScene function";
             return ;
         }
 

--- a/Plugin/src/SofaPython3/SceneLoaderPY3.h
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.h
@@ -58,6 +58,9 @@ public:
 
     /// get the list of file extensions
     virtual void getExtensionList(ExtensionList* list) override;
+
+    bool syntaxForAddingRequiredPlugin(const std::string& pluginName, const std::vector<std::string>& listComponents,
+                                       std::ostream& ss, sofa::simulation::Node* nodeWhereAdded) override;
 };
 
 } // namespace sofapython3


### PR DESCRIPTION
Follows https://github.com/sofa-framework/sofa/pull/3799

Allows to format the warning message such as:

```
[WARNING] [SceneCheckMissingRequiredPlugin] This scene is using component defined in plugins but is not importing the required plugins.  
  Your scene may not work on a sofa environment with different pre-loaded plugins.  
  To fix your scene and remove this warning you just need to cut & paste the following lines at the beginning of your scene:   
  root.addObject('RequiredPlugin', name='Sofa.Component.AnimationLoop') # Needed to use components [FreeMotionAnimationLoop]  
  root.addObject('RequiredPlugin', name='Sofa.Component.Collision.Detection.Algorithm') # Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,BruteForceDetection,CollisionPipeline]  
  root.addObject('RequiredPlugin', name='Sofa.Component.Collision.Detection.Intersection') # Needed to use components [LocalMinDistance]  
```