### PR TITLE
Fix SOFAPYTHON_PLUGINS_PATH env var with Windows (and add a warning error)

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -240,15 +240,26 @@ void PythonEnvironment::Init()
 
     /// Add the directories listed in the SOFAPYTHON3_PLUGINS_PATH environnement
     /// variable to sys.path
-    std::string envVarName = "SOFAPYTHON3_PLUGINS_PATH";
+    const std::string envVarName = "SOFAPYTHON3_PLUGINS_PATH";
     const std::string deprecatedEnvVarName = "SOFAPYTHON_PLUGINS_PATH";
+    std::string usedEnvVarName = envVarName;
 
-    char* pathVar = getenv(deprecatedEnvVarName.c_str());
-    if (pathVar != nullptr)
+    char* deprecatedPathVar = getenv(deprecatedEnvVarName.c_str());
+    char* pathVar = getenv(envVarName.c_str());
+    
+    // case where only the deprecated env var is set
+    if (pathVar != nullptr && deprecatedPathVar == nullptr)
     {
-        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " environment variable is deprecated, use SOFAPYTHON3_PLUGINS_PATH instead.";
-        envVarName = "SOFAPYTHON_PLUGINS_PATH";
+        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " environment variable is deprecated, use " << envVarName << " instead.";
+        usedEnvVarName = "SOFAPYTHON_PLUGINS_PATH";
     }
+    // case where both env vars are set
+    else if (pathVar != nullptr && deprecatedPathVar != nullptr)
+    {
+        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " and " << envVarName << " environment variables are both set."
+        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " is deprecated, and only " << envVarName << " will be used.";
+    }
+    
     sofa::helper::system::FileRepository pluginPathsRepository(envVarName.c_str());
     const auto& pluginPaths = pluginPathsRepository.getPaths();
     for (auto pluginPath : pluginPaths)

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -238,20 +238,23 @@ void PythonEnvironment::Init()
         }
     }
 
-    /// Add the directories listed in the SOFAPYTHON_PLUGINS_PATH environnement
-    /// variable (colon-separated) to sys.path
-    char * pathVar = getenv("SOFAPYTHON_PLUGINS_PATH");
+    /// Add the directories listed in the SOFAPYTHON3_PLUGINS_PATH environnement
+    /// variable to sys.path
+    std::string envVarName = "SOFAPYTHON3_PLUGINS_PATH";
+    const std::string deprecatedEnvVarName = "SOFAPYTHON_PLUGINS_PATH";
+
+    char* pathVar = getenv(deprecatedEnvVarName.c_str());
     if (pathVar != nullptr)
     {
-        std::istringstream ss(pathVar);
-        std::string path;
-        while(std::getline(ss, path, ':'))
-        {
-            if (FileSystem::exists(path))
-                addPythonModulePathsFromDirectory(path);
-            else
-                msg_warning("SofaPython3") << "no such directory: '" + path + "'";
-        }
+        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " environment variable is deprecated, use SOFAPYTHON3_PLUGINS_PATH instead.";
+        envVarName = "SOFAPYTHON_PLUGINS_PATH";
+    }
+    sofa::helper::system::FileRepository pluginPathsRepository(envVarName.c_str());
+    const auto& pluginPaths = pluginPathsRepository.getPaths();
+    for (auto pluginPath : pluginPaths)
+    {
+        std::string cleanPath = FileSystem::cleanPath(pluginPath);
+        addPythonModulePath(cleanPath);
     }
 
     // Add sites-packages wrt the plugin
@@ -332,6 +335,12 @@ void PythonEnvironment::Release()
 
 void PythonEnvironment::addPythonModulePath(const std::string& path)
 {
+    if (!(FileSystem::exists(path) && FileSystem::isDirectory(path)))
+    {
+        msg_warning("SofaPython3") << "Could not add '" + path + "'" << "(does not exist or is not a directory)";
+        return;
+    }
+
     PythonEnvironmentData* data = getStaticData() ;
     if (  data->addedPath.find(path)==data->addedPath.end())
     {

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -256,7 +256,7 @@ void PythonEnvironment::Init()
     // case where both env vars are set
     else if (pathVar != nullptr && deprecatedPathVar != nullptr)
     {
-        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " and " << envVarName << " environment variables are both set."
+        msg_deprecated("SofaPython3") << deprecatedEnvVarName << " and " << envVarName << " environment variables are both set.";
         msg_deprecated("SofaPython3") << deprecatedEnvVarName << " is deprecated, and only " << envVarName << " will be used.";
     }
     

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -337,7 +337,7 @@ void PythonEnvironment::addPythonModulePath(const std::string& path)
 {
     if (!(FileSystem::exists(path) && FileSystem::isDirectory(path)))
     {
-        msg_warning("SofaPython3") << "Could not add '" + path + "'" << "(does not exist or is not a directory)";
+        msg_warning("SofaPython3") << "Could not add '" + path + "'" << " to sys.path (it does not exist or is not a directory)";
         return;
     }
 


### PR DESCRIPTION
and deprecate it in favor of SOFAPYTHON3_PLUGINS_PATH to be more consistent with the other names.

Use `system::FileRepository` instead of manually handle the content of the env var.
Especially that it was not handling the correct separating marker for Windows (which is ";" instead of ":" apparently)

**PLUS**
Added a message when the path given to `addPythonModulePath` is not correct.
This actually happens often, e.g BeamAdapter/Cosserat did not update their cmake config when the python3 was renamed.
With Cosserat you get `Added 'D:/sofa/src/plugins/CosseratPlugin/python' to sys.path` even if the directory does not exist.