### PR TITLE
Support copy of some binary files

### DIFF
--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -34,12 +34,11 @@ macro(SP3_get_python_user_site)
     endif()
 endmacro()
 
-# - Create a python package by copying the source directory to the destination directory. Every files within the
-#   source directory will be configured with the current cmake variables available (see CMake configure_file documentation)
+# - Create a python package by copying the source directory to the destination directory.
 #
 # SP3_add_python_package(PACKAGE_NAME SOURCE_DIRECTORY TARGET_DIRECTORY)
-#  SOURCE_DIRECTORY   - (input) the source path of the directory to be configured and copied to the target directory.
-#  TARGET_DIRECTORY   - (input) the target path of the directory that will contain the configured files.
+#  SOURCE_DIRECTORY   - (input) the source path of the directory to be copied to the target directory.
+#  TARGET_DIRECTORY   - (input) the target path of the directory that will contain the copied files.
 #                               Files will be at LIBRARY_OUTPUT_DIRECTORY/SP3_PYTHON_PACKAGES_DIRECTORY/TARGET_DIRECTORY.
 function(SP3_add_python_package)
     set(options)
@@ -53,11 +52,7 @@ function(SP3_add_python_package)
     file(GLOB_RECURSE files RELATIVE ${A_SOURCE_DIRECTORY} ${A_SOURCE_DIRECTORY}/*)
     foreach(file_relative_path ${files})
         set(file_absolute_path ${A_SOURCE_DIRECTORY}/${file_relative_path})
-        configure_file(
-            ${file_absolute_path}
-            ${OUTPUT_DIRECTORY}/${file_relative_path}
-            @ONLY
-        )
+        file(COPY ${file_absolute_path} DESTINATION ${OUTPUT_DIRECTORY}/${file_relative_path})
         get_filename_component(relative_directory ${file_relative_path} DIRECTORY)
         install(
             FILES "${OUTPUT_DIRECTORY}/${file_relative_path}"

--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -52,8 +52,8 @@ function(SP3_add_python_package)
     file(GLOB_RECURSE files RELATIVE ${A_SOURCE_DIRECTORY} ${A_SOURCE_DIRECTORY}/*)
     foreach(file_relative_path ${files})
         set(file_absolute_path ${A_SOURCE_DIRECTORY}/${file_relative_path})
-        file(COPY ${file_absolute_path} DESTINATION ${OUTPUT_DIRECTORY}/${file_relative_path})
         get_filename_component(relative_directory ${file_relative_path} DIRECTORY)
+        file(COPY ${file_absolute_path} DESTINATION ${OUTPUT_DIRECTORY}/${relative_directory})
         install(
             FILES "${OUTPUT_DIRECTORY}/${file_relative_path}"
             DESTINATION "lib/${SP3_PYTHON_PACKAGES_DIRECTORY}/${A_TARGET_DIRECTORY}/${relative_directory}"

--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -50,32 +50,14 @@ function(SP3_add_python_package)
 
     set(OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${SP3_PYTHON_PACKAGES_DIRECTORY}/${A_TARGET_DIRECTORY})
 
-    set(KNOWN_BINARY_EXTENSIONS ".stl" ".vtk")
-
     file(GLOB_RECURSE files RELATIVE ${A_SOURCE_DIRECTORY} ${A_SOURCE_DIRECTORY}/*)
     foreach(file_relative_path ${files})
         set(file_absolute_path ${A_SOURCE_DIRECTORY}/${file_relative_path})
-        get_filename_component(extension ${file_relative_path} EXT)
-        set(IS_KNOWN_BINARY_FILE BOOL FALSE)
-        if (${extension})
-            list(FIND KNOWN_BINARY_EXTENSIONS ${extension} _index)
-            if (${_index} GREATER -1)
-                set(IS_KNOWN_BINARY_FILE TRUE)
-            endif()
-        endif()
-        if (IS_KNOWN_BINARY_FILE)
-            configure_file(
-                ${file_absolute_path}
-                ${OUTPUT_DIRECTORY}/${file_relative_path}
-                COPYONLY
-            )
-        else()
-            configure_file(
-                ${file_absolute_path}
-                ${OUTPUT_DIRECTORY}/${file_relative_path}
-                @ONLY
-            )
-        endif()
+        configure_file(
+            ${file_absolute_path}
+            ${OUTPUT_DIRECTORY}/${file_relative_path}
+            @ONLY
+        )
         get_filename_component(relative_directory ${file_relative_path} DIRECTORY)
         install(
             FILES "${OUTPUT_DIRECTORY}/${file_relative_path}"

--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -50,14 +50,32 @@ function(SP3_add_python_package)
 
     set(OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${SP3_PYTHON_PACKAGES_DIRECTORY}/${A_TARGET_DIRECTORY})
 
+    set(KNOWN_BINARY_EXTENSIONS ".stl" ".vtk")
+
     file(GLOB_RECURSE files RELATIVE ${A_SOURCE_DIRECTORY} ${A_SOURCE_DIRECTORY}/*)
     foreach(file_relative_path ${files})
         set(file_absolute_path ${A_SOURCE_DIRECTORY}/${file_relative_path})
-        configure_file(
-            ${file_absolute_path}
-            ${OUTPUT_DIRECTORY}/${file_relative_path}
-            @ONLY
-        )
+        get_filename_component(extension ${file_relative_path} EXT)
+        set(IS_KNOWN_BINARY_FILE BOOL FALSE)
+        if (${extension})
+            list(FIND KNOWN_BINARY_EXTENSIONS ${extension} _index)
+            if (${_index} GREATER -1)
+                set(IS_KNOWN_BINARY_FILE TRUE)
+            endif()
+        endif()
+        if (IS_KNOWN_BINARY_FILE)
+            configure_file(
+                ${file_absolute_path}
+                ${OUTPUT_DIRECTORY}/${file_relative_path}
+                COPYONLY
+            )
+        else()
+            configure_file(
+                ${file_absolute_path}
+                ${OUTPUT_DIRECTORY}/${file_relative_path}
+                @ONLY
+            )
+        endif()
         get_filename_component(relative_directory ${file_relative_path} DIRECTORY)
         install(
             FILES "${OUTPUT_DIRECTORY}/${file_relative_path}"


### PR DESCRIPTION
The command `configure_file` with attribute `@ONLY` does not make sense for binary files. Actually, it corrupts them when copying them. So they have to be handled differently.
I don' t know how to detect that a file is binary or not, so I adopted a strategy where I checked if the file extension matches a list of known extensions. This is not generic...

For the record, we have binary files in Python modules in SoftRobots. It corresponds to meshes. The Finger for example