### PR TITLE
Fix v23.06 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           echo "RELEASE_DATE=$RELEASE_DATE" | tee -a $GITHUB_ENV
 
       - name: Delete old release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:
           tag_name: ${{ env.RELEASE_TAGNAME }}
           delete_release: true


### PR DESCRIPTION
- Update ci.yml to run CI on the v23.06 branch (and not master)
- Temporarily disable MacOS build as it seems down

