### PR TITLE
Fix deploy artifacts as MacOS is temporarily disabled.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,4 +228,3 @@ jobs:
           files: |
             artifacts/${{ env.PROJECT_NAME }}_*_Linux.zip
             artifacts/${{ env.PROJECT_NAME }}_*_Windows.zip
-            artifacts/${{ env.PROJECT_NAME }}_*_macOS.zip


### PR DESCRIPTION
#363 broke the _Deploy artifact_ action as MacOS is removed from CI.
This did not appear at the PR CI as this action is not launched from open PR.