### PR TITLE
Fix 23.06 wrong assets source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
           fail_on_unmatched_files: true
+          target_commitish: ${{ env.RELEASE_NAME }}
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         sofa_branch: [v23.06]
         python_version: ['3.8']
 
@@ -222,10 +222,11 @@ jobs:
         with:
           name: ${{ env.RELEASE_NAME }}
           tag_name: ${{ env.RELEASE_TAGNAME }}
-          fail_on_unmatched_files: true
+          fail_on_unmatched_files: false
           target_commitish: ${{ env.RELEASE_NAME }}
           body: |
             Last updated on ${{ env.RELEASE_DATE }}
           files: |
             artifacts/${{ env.PROJECT_NAME }}_*_Linux.zip
             artifacts/${{ env.PROJECT_NAME }}_*_Windows.zip
+            artifacts/${{ env.PROJECT_NAME }}_*_macOS.zip


### PR DESCRIPTION
The `softprops/action-gh-release` Github action used in the CI to deploy assets was incorrectly configured to the `master` branch (default behavior), instead of the current release set by the `sofa_branch` field in the `build-and-test` matrix.
This lead to the following undesired behavior:
- source code archives (zip and tar) were generated from master branch instead of release branch. Other assets (releases for Windows, Linux and MacOS) were generated from correct branch.
- release tag pushed by this action (tag in the form `release-<version>`) was incorrectly set to `master` branch, which is invalid when current release is not `master` (such as `v<version>`)