### PR TITLE
[Plugin] Add a public function init() to allow loading the plugin statically

### DIFF
--- a/Plugin/src/SofaPython3/initModule.cpp
+++ b/Plugin/src/SofaPython3/initModule.cpp
@@ -23,6 +23,8 @@
 #include "PythonEnvironment.h"
 using sofapython3::PythonEnvironment;
 
+#include <SofaPython3/initModule.h>
+
 #include <sofa/core/init.h>
 #include <sofa/defaulttype/init.h>
 #include <sofa/simulation/init.h>
@@ -44,11 +46,11 @@ void initExternalModule()
     static bool first = true;
     if (first)
     {
-        sofa::core::init();
+        sofa::helper::init();
         sofa::defaulttype::init();
+        sofa::core::init();
         sofa::simulation::core::init();
         sofa::simulation::graph::init();
-        sofa::helper::init();
 
         PythonEnvironment::Init();
         first = false;
@@ -86,4 +88,12 @@ bool moduleIsInitialized()
     return PythonEnvironment::isInitialized();
 }
 
+}
+
+namespace sofapython3
+{
+    void init()
+    {
+        initExternalModule();
+    }
 }

--- a/Plugin/src/SofaPython3/initModule.h
+++ b/Plugin/src/SofaPython3/initModule.h
@@ -22,4 +22,7 @@
 
 #include <SofaPython3/config.h>
 
-
+namespace sofapython3
+{
+    SOFAPYTHON3_API void init();
+}


### PR DESCRIPTION
The entrypoint of the plugin SofaPython3 could not be called from somewhere else, for example to force-load the library (dll).