### PR TITLE
[GUIManager] Add SofaGLFW and SofaImgui at runtime

### DIFF
--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
@@ -107,6 +107,20 @@ PYBIND11_MODULE(Gui, m) {
     sofa::gui::headlessrecorder::init();
 #endif
 
+    const auto listAdditionalGUIs = { "SofaGLFW", "SofaImGui" };
+
+    for (const auto& gui : listAdditionalGUIs)
+    {
+        try
+        {
+            py::module_ sys = py::module_::import(gui);
+        }
+        catch (const py::error_already_set& e)
+        {
+            dmsg_info("Sofa.Gui") << gui << " could not be loaded. Reason: " << e.what();
+        }
+    }
+
     sofa::core::init();
 
     moduleAddBaseGui(m);

--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Module_SofaGui.cpp
@@ -113,7 +113,7 @@ PYBIND11_MODULE(Gui, m) {
     {
         try
         {
-            py::module_ sys = py::module_::import(gui);
+            py::module sys = py::module::import(gui);
         }
         catch (const py::error_already_set& e)
         {


### PR DESCRIPTION
Alternative to #380 

Needs
- https://github.com/sofa-framework/SofaGLFW/pull/94
- https://github.com/sofa-framework/SofaGLFW/pull/95

to enable glfw and imgui to be loadable at runtime by the GUIManager