### PR TITLE
[SceneLoader] Add a special error message handler for DeprecationWarning

### DIFF
--- a/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
@@ -129,9 +129,18 @@ void SceneLoaderPY3::loadSceneWithArguments(const char *filename,
         root_out->setInstanciationSourceFilePos(0);
     }catch(py::error_already_set& e)
     {
-        msg_error() << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
-                    << "Python exception: " << msgendl
-                    << "  " << e.what();
+        if( py::isinstance(e.type(), py::eval("type(DeprecationWarning)")) )
+        {
+            msg_deprecated() << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
+                        << "Python exception: " << msgendl
+                        << "  " << e.what();
+        }else
+        {
+            msg_error() << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
+                        << "Python exception: " << msgendl
+                        << "  " << e.what();
+        }
+
     }
 
 }

--- a/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
@@ -129,16 +129,16 @@ void SceneLoaderPY3::loadSceneWithArguments(const char *filename,
         root_out->setInstanciationSourceFilePos(0);
     }catch(py::error_already_set& e)
     {
+        std::stringstream ss;
+        ss << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
+            << "Python exception: " << msgendl
+            << "  " << e.what();
         if( py::isinstance(e.type(), py::eval("type(DeprecationWarning)")) )
         {
-            msg_deprecated() << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
-                        << "Python exception: " << msgendl
-                        << "  " << e.what();
+            msg_deprecated() << ss.str();
         }else
         {
-            msg_error() << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
-                        << "Python exception: " << msgendl
-                        << "  " << e.what();
+            msg_error() << ss.str();
         }
 
     }


### PR DESCRIPTION
Currently DeprecationWarning exception risen by python code are reported as  msg_error() 
which is misleading. The PR detect it so it is reported with msg_deprecated() 

This is the source of this: 
https://github.com/SofaDefrost/STLIB/pull/117