### PR TITLE
Introduce bindings to linear system

### DIFF
--- a/bindings/Modules/CMakeLists.txt
+++ b/bindings/Modules/CMakeLists.txt
@@ -1,6 +1,12 @@
 project(Bindings.Modules)
 
-set(MODULEBINDINGS_MODULE_LIST SofaBaseTopology SofaDeformable SofaLinearSolver SofaConstraintSolver)
+set(MODULEBINDINGS_MODULE_LIST
+    SofaBaseTopology
+    SofaDeformable
+    SofaLinearSolver
+    SofaLinearSystem
+    SofaConstraintSolver
+)
 
 sofa_find_package(Sofa.GL QUIET)
 if(Sofa.GL_FOUND)

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
@@ -60,7 +60,8 @@ template<class TBlock>
 void bindLinearSystems(py::module &m)
 {
     using CRS = sofa::linearalgebra::CompressedRowSparseMatrix<TBlock>;
-    using CRSLinearSystem = sofa::component::linearsystem::TypedMatrixLinearSystem<CRS, sofa::linearalgebra::FullVector<SReal> >;
+    using Real = typename CRS::Real;
+    using CRSLinearSystem = sofa::component::linearsystem::TypedMatrixLinearSystem<CRS, sofa::linearalgebra::FullVector<Real> >;
 
     const std::string typeName = CRSLinearSystem::GetClass()->className + CRSLinearSystem::GetCustomTemplateName();
 

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
@@ -1,0 +1,111 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaPython3/SofaLinearSystem/Binding_LinearSystem.h>
+#include <SofaPython3/SofaLinearSystem/Binding_LinearSystem_doc.h>
+#include <pybind11/pybind11.h>
+
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/PythonFactory.h>
+
+#include <sofa/component/linearsystem/TypedMatrixLinearSystem.h>
+#include <pybind11/eigen.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+
+
+namespace py { using namespace pybind11; }
+
+namespace sofapython3 {
+
+using EigenSparseMatrix = Eigen::SparseMatrix<SReal, Eigen::RowMajor>;
+using EigenMatrixMap = Eigen::Map<Eigen::SparseMatrix<SReal, Eigen::RowMajor> >;
+using Vector = Eigen::Matrix<SReal,Eigen::Dynamic, 1>;
+using EigenVectorMap = Eigen::Map<Vector>;
+
+template<class TBlock>
+EigenSparseMatrix toEigen(sofa::linearalgebra::CompressedRowSparseMatrix<TBlock>& matrix)
+{
+    sofa::linearalgebra::CompressedRowSparseMatrix<typename TBlock::Real> filtered;
+    filtered.copyNonZeros(matrix);
+    filtered.compress();
+    return EigenMatrixMap(filtered.rows(), filtered.cols(), filtered.getColsValue().size(),
+            (EigenMatrixMap::StorageIndex*)filtered.rowBegin.data(), (EigenMatrixMap::StorageIndex*)filtered.colsIndex.data(), filtered.colsValue.data());
+}
+
+template<>
+EigenSparseMatrix toEigen<SReal>(sofa::linearalgebra::CompressedRowSparseMatrix<SReal>& matrix)
+{
+    return EigenMatrixMap(matrix.rows(), matrix.cols(), matrix.getColsValue().size(),
+                    (EigenMatrixMap::StorageIndex*)matrix.rowBegin.data(), (EigenMatrixMap::StorageIndex*)matrix.colsIndex.data(), matrix.colsValue.data());
+}
+
+template<class TBlock>
+void bindLinearSystems(py::module &m)
+{
+    using CRS = sofa::linearalgebra::CompressedRowSparseMatrix<TBlock>;
+    using CRSLinearSystem = sofa::component::linearsystem::TypedMatrixLinearSystem<CRS, sofa::linearalgebra::FullVector<SReal> >;
+
+    const std::string typeName = CRSLinearSystem::GetClass()->className + CRSLinearSystem::GetCustomTemplateName();
+
+    py::class_<CRSLinearSystem,
+               sofa::core::objectmodel::BaseObject,
+               sofapython3::py_shared_ptr<CRSLinearSystem> > c(m, typeName.c_str(), sofapython3::doc::linearsystem::linearSystemClass);
+
+    c.def("A", [](CRSLinearSystem& self) -> EigenSparseMatrix
+    {
+        if (CRS* matrix = self.getSystemMatrix())
+        {
+            return toEigen(*matrix);
+        }
+        return {};
+    }, sofapython3::doc::linearsystem::linearSystem_A);
+
+    c.def("b", [](CRSLinearSystem& self) -> Vector
+    {
+        if (auto* vector = self.getRHSVector())
+        {
+            return EigenVectorMap(vector->ptr(), vector->size());
+        }
+        return {};
+    }, sofapython3::doc::linearsystem::linearSystem_b);
+
+    c.def("x", [](CRSLinearSystem& self) -> Vector
+    {
+        if (auto* vector = self.getSolutionVector())
+        {
+            return EigenVectorMap(vector->ptr(), vector->size());
+        }
+        return {};
+    }, sofapython3::doc::linearsystem::linearSystem_x);
+
+
+    /// register the binding in the downcasting subsystem
+    PythonFactory::registerType<CRSLinearSystem>([](sofa::core::objectmodel::Base* object)
+    {
+        return py::cast(dynamic_cast<CRSLinearSystem*>(object));
+    });
+}
+
+void moduleAddLinearSystem(py::module &m)
+{
+    bindLinearSystems<SReal>(m);
+    bindLinearSystems<sofa::type::Mat<3, 3, SReal> >(m);
+}
+
+}

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
@@ -87,6 +87,10 @@ void bindLinearSystems(py::module &m)
     {
         if (CRS* matrix = self.getSystemMatrix())
         {
+            if (matrix->colsValue.empty()) //null matrix: contains no entries
+            {
+                return EigenSparseMatrix<Real>{matrix->rows(), matrix->cols()};
+            }
             return toEigen(*matrix);
         }
         return {};

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.cpp
@@ -51,6 +51,7 @@ EigenSparseMatrix toEigen(sofa::linearalgebra::CompressedRowSparseMatrix<TBlock>
 template<>
 EigenSparseMatrix toEigen<SReal>(sofa::linearalgebra::CompressedRowSparseMatrix<SReal>& matrix)
 {
+    matrix.compress();
     return EigenMatrixMap(matrix.rows(), matrix.cols(), matrix.getColsValue().size(),
                     (EigenMatrixMap::StorageIndex*)matrix.rowBegin.data(), (EigenMatrixMap::StorageIndex*)matrix.colsIndex.data(), matrix.colsValue.data());
 }

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.h
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem.h
@@ -1,0 +1,31 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3
+{
+
+void moduleAddLinearSystem(pybind11::module &m);
+
+} /// namespace sofapython3
+

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem_doc.h
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Binding_LinearSystem_doc.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::linearsystem {
+
+static auto linearSystemClass =
+R"(
+Linear system. Supports only CompressedRowSparseMatrix.
+
+example:
+------------
+
+linear_system = root.addObject('MatrixLinearSystem', template='CompressedRowSparseMatrixd')
+)";
+
+static auto linearSystem_A =
+R"(
+Returns the global system matrix as a scipy sparse matrix
+
+example:
+------------
+linear_system = root.addObject('MatrixLinearSystem', template='CompressedRowSparseMatrixd')
+matrix = linear_system.A()
+)";
+
+static auto linearSystem_b =
+R"(
+Returns the global system right hand side as a numpy array
+
+example:
+------------
+linear_system = root.addObject('MatrixLinearSystem', template='CompressedRowSparseMatrixd')
+matrix = linear_system.b()
+)";
+
+static auto linearSystem_x =
+R"(
+Returns the global system solution vector as a numpy array
+
+example:
+------------
+linear_system = root.addObject('MatrixLinearSystem', template='CompressedRowSparseMatrixd')
+matrix = linear_system.x()
+)";
+
+} // namespace sofapython3::doc::baseCamera

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(Bindings.Modules.SofaLinearSystem)
+
+set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinearSystem.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinearSystem_doc.h
+)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_LinearSystem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Module_SofaLinearSystem.cpp
+)
+
+if (NOT TARGET SofaPython3::Plugin)
+    find_package(SofaPython3 REQUIRED COMPONENTS Plugin Bindings.Sofa)
+endif()
+
+sofa_find_package(Sofa.Component.LinearSystem REQUIRED)
+
+SP3_add_python_module(
+    TARGET       ${PROJECT_NAME}
+    PACKAGE      Bindings.Modules
+    MODULE       SofaLinearSystem
+    DESTINATION  Sofa
+    SOURCES      ${SOURCE_FILES}
+    HEADERS      ${HEADER_FILES}
+    DEPENDS      Sofa.Component.LinearSystem SofaPython3::Plugin SofaPython3::Bindings.Sofa.Core
+)

--- a/bindings/Modules/src/SofaPython3/SofaLinearSystem/Module_SofaLinearSystem.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaLinearSystem/Module_SofaLinearSystem.cpp
@@ -1,0 +1,33 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <SofaPython3/SofaLinearSystem/Binding_LinearSystem.h>
+
+namespace sofapython3
+{
+
+PYBIND11_MODULE(SofaLinearSystem, m)
+{
+    moduleAddLinearSystem(m);
+}
+
+}  // namespace sofapython3
+

--- a/examples/access_mass_matrix.py
+++ b/examples/access_mass_matrix.py
@@ -1,6 +1,7 @@
 # Required import for python
 import Sofa
 import SofaRuntime
+from Sofa import SofaLinearSystem
 from scipy import sparse
 from scipy import linalg
 from matplotlib import pyplot as plt
@@ -8,6 +9,18 @@ import numpy as np
 
 exportCSV = False
 showImage = True
+
+
+def create_beam(node, id, offset):
+
+    node.addObject('MechanicalObject', name="DoFs")
+    mass = node.addObject('MeshMatrixMass', name="mass" + str(id), totalMass=320)
+    node.addObject('RegularGridTopology', name="grid", nx=4, ny=4, nz=20, xmin=-9 + offset, xmax=-6 + offset, ymin=0, ymax=3, zmin=0, zmax=19)
+    node.addObject('BoxROI', name="box", box=[-10 + offset, -1, -0.0001,  -5 + offset, 4, 0.0001])
+    node.addObject('FixedProjectiveConstraint', indices="@box.indices")
+    node.addObject('HexahedronFEMForceField', name="FEM", youngModulus=4000, poissonRatio=0.3, method="large")
+
+    node.addObject(LocalMatrixAccessController('MatrixAccessor', name='matrixAccessor', mass=mass))
 
 # Function called when the scene graph is being created
 def createScene(root):
@@ -17,6 +30,7 @@ def createScene(root):
     root.addObject("RequiredPlugin", pluginName=['Sofa.Component.Constraint.Projective',
                                                     'Sofa.Component.Engine.Select',
                                                     'Sofa.Component.LinearSolver.Direct',
+                                                    'Sofa.Component.LinearSystem',
                                                     'Sofa.Component.Mass',
                                                     'Sofa.Component.ODESolver.Backward',
                                                     'Sofa.Component.SolidMechanics.FEM.Elastic',
@@ -29,22 +43,34 @@ def createScene(root):
     root.addObject('DefaultVisualManagerLoop')
 
     root.addObject('EulerImplicitSolver', rayleighStiffness="0.1", rayleighMass="0.1")
-    root.addObject('SparseLDLSolver', applyPermutation="false", template="CompressedRowSparseMatrixd")
 
-    root.addObject('MechanicalObject', name="DoFs")
-    mass = root.addObject('MeshMatrixMass', name="mass", totalMass="320")
-    root.addObject('RegularGridTopology', name="grid", nx="4", ny="4", nz="20", xmin="-9", xmax="-6", ymin="0", ymax="3", zmin="0", zmax="19")
-    root.addObject('BoxROI', name="box", box="-10 -1 -0.0001  -5 4 0.0001")
-    root.addObject('FixedConstraint', indices="@box.indices")
-    root.addObject('HexahedronFEMForceField', name="FEM", youngModulus="4000", poissonRatio="0.3", method="large")
+    matrices = root.addChild('matrices')
+    # in this Node, two linear systems are declared:
+    # 1) one used to assemble the global system used by the solver, and
+    # 2) another assembling only the mass contributions
+    matrices.addObject('MatrixLinearSystem', template="CompressedRowSparseMatrixMat3x3d", name='system')
+    mass_matrix = matrices.addObject('MatrixLinearSystem', template="CompressedRowSparseMatrixMat3x3d", name='M',
+                                     assembleStiffness=False, assembleDamping=False, assembleGeometricStiffness=False,
+                                     applyProjectiveConstraints=False)  # This system assembles only the mass contributions
+    matrices.addObject(GlobalMatrixAccessController('MatrixAccessor', name='matrixAccessor', mass_matrix=mass_matrix))
 
-    root.addObject(MatrixAccessController('MatrixAccessor', name='matrixAccessor', mass=mass))
+    # This component distributes the matrix contributions to the other systems
+    root.addObject('CompositeLinearSystem', template="CompressedRowSparseMatrixMat3x3d", name="solverSystem",
+                   linearSystems="@matrices/system @matrices/M", solverLinearSystem="@matrices/system")
+    # It is important to define the linear system in the linear solver: the CompositeLinearSystem
+    root.addObject('SparseLDLSolver', ordering='Natural', template="CompressedRowSparseMatrixMat3x3d",
+                   linearSystem="@solverSystem")
+
+    beam1 = root.addChild('Beam1')
+    create_beam(beam1, 1, 0)
+
+    beam2 = root.addChild('Beam2')
+    create_beam(beam2, 2, 10)
 
     return root
 
 
-class MatrixAccessController(Sofa.Core.Controller):
-
+class LocalMatrixAccessController(Sofa.Core.Controller):
 
     def __init__(self, *args, **kwargs):
         Sofa.Core.Controller.__init__(self, *args, **kwargs)
@@ -54,7 +80,7 @@ class MatrixAccessController(Sofa.Core.Controller):
         mass_matrix = self.mass.assembleMMatrix()
 
         print('====================================')
-        print('Stiffness matrix')
+        print('Mass matrix', self.mass.getPathName())
         print('====================================')
         print('dtype: ' + str(mass_matrix.dtype))
         print('shape: ' + str(mass_matrix.shape))
@@ -63,7 +89,32 @@ class MatrixAccessController(Sofa.Core.Controller):
         print('norm: ' + str(sparse.linalg.norm(mass_matrix)))
 
         if exportCSV:
-            np.savetxt('mass.csv', mass_matrix.toarray(), delimiter=',')
+            np.savetxt(self.mass.getName() + '.csv', mass_matrix.toarray(), delimiter=',')
+        if showImage:
+            plt.imshow(mass_matrix.toarray(), interpolation='nearest', cmap='gist_gray')
+            plt.show(block=False)
+
+
+class GlobalMatrixAccessController(Sofa.Core.Controller):
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.Controller.__init__(self, *args, **kwargs)
+        self.mass_system = kwargs.get("mass_matrix")
+
+    def onAnimateEndEvent(self, event):
+        mass_matrix = self.mass_system.A()
+
+        print('====================================')
+        print('Mass matrix', self.mass_system.getPathName())
+        print('====================================')
+        print('dtype: ' + str(mass_matrix.dtype))
+        print('shape: ' + str(mass_matrix.shape))
+        print('ndim: ' + str(mass_matrix.ndim))
+        print('nnz: ' + str(mass_matrix.nnz))
+        print('norm: ' + str(sparse.linalg.norm(mass_matrix)))
+
+        if exportCSV:
+            np.savetxt(self.mass_system.getName() + '.csv', mass_matrix.toarray(), delimiter=',')
         if showImage:
             plt.imshow(mass_matrix.toarray(), interpolation='nearest', cmap='gist_gray')
             plt.show(block=False)


### PR DESCRIPTION
The bindings are very similar to the ones in SofaLinearSolver, but they can act on a LinearSystem. It is needed when accessing a LinearSystem which is not the one used by a LinearSolver, as in the provided example