### PR TITLE
Fix out-of-tree compilation of dependencies

### DIFF
--- a/SofaPython3Config.cmake.in
+++ b/SofaPython3Config.cmake.in
@@ -10,7 +10,7 @@ include(SofaPython3Tools)
 
 # Find Python3
 if(NOT Python_FOUND)
-    find_package(Python @Python_VERSION@ QUIET REQUIRED COMPONENTS Interpreter Development)
+    find_package(Python @Python_VERSION@ EXACT QUIET REQUIRED COMPONENTS Interpreter Development)
 endif()
 
 # Find pybind11


### PR DESCRIPTION
Add EXACT to find_package of python because version should not mismatch