### PR TITLE
Replace deprecated imp by importlib

### DIFF
--- a/bindings/Sofa/package/livecoding.py
+++ b/bindings/Sofa/package/livecoding.py
@@ -25,14 +25,25 @@
 #******************************************************************************/
 
 import traceback
-import imp
 import types
 import gc
 import os
 
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
 def mimport(modulename, filename):
-    f = open(filename, 'r')
-    return imp.load_module(modulename, f, filename, (modulename, 'r', imp.PY_SOURCE))
+    return load_source(modulename,filename)
 
 def mreload(modulepath):
         try:


### PR DESCRIPTION
https://docs.python.org/dev/whatsnew/3.12.html#imp

Imp has been deprecated since Python3 3.4 (!) and has been removed in 3.12.1
Hitting first macOS users because homebrew recently updated their version.

More context : https://discuss.python.org/t/how-do-i-migrate-from-imp/27885/13

---

`livecoding.py` is called in PythonEnvironment, so it is throwing an error every time.

This PR replaces imp by importlib.

I just tested by calling directly the file (and using the onReimpAFile(file).
There is no test at all currently and this onReimpAFile() function is only used for prefab.

Fix partially https://github.com/sofa-framework/sofa/discussions/4624