### PR TITLE
 [Slicer-SOFA integration] Add compatibility with GCC

### DIFF
--- a/Testing/src/SofaPython3Testing/PythonTest.h
+++ b/Testing/src/SofaPython3Testing/PythonTest.h
@@ -24,8 +24,19 @@
 #include <SofaPython3Testing/config.h>
 #include <sofa/testing/BaseTest.h>
 
-#include <filesystem>
+#if __has_include(<filesystem>)
+  #include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+  #include <experimental/filesystem>
+  namespace std {
+      namespace filesystem = experimental::filesystem;
+  }
+#else
+  error "Missing the <filesystem> header."
+#endif
+
 using std::filesystem::path;
+
 
 namespace sofapython3
 {


### PR DESCRIPTION
This solves the following error, which is produced with GCC 7 due to the fact that std::filesystem is an experimental feature.

```
[ 98%] Building CXX object external_directories/SofaPython3/Testing/CMakeFiles/SofaPython3Testing.dir/src/SofaPython3Testing/PythonTest.cpp.o
In file included from /home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTestExtractor.h:22:0,
                 from /home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.cpp:38:
/home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.h:28:12: error: ‘std::filesystem’ has not been declared
 using std::filesystem::path;
            ^~~~~~~~~~
/home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.h: In static member function ‘static std::string sofapython3::PythonTest::getTestName(const testing::TestParamInfo<sofapython3::PythonTestData>&)’:
/home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.h:73:67: error: ‘path’ was not declared in this scope
             return  std::to_string(p.index)+"_"+p.param.testgroup+path(p.param.filepath).stem().string();
                                                                   ^~~~
/home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.h:73:67: note: suggested alternative: ‘putw’
             return  std::to_string(p.index)+"_"+p.param.testgroup+path(p.param.filepath).stem().string();
                                                                   ^~~~
                                                                   putw
/home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.h:74:63: error: ‘path’ was not declared in this scope
         return  std::to_string(p.index)+"_"+p.param.testgroup+path(p.param.filepath).stem().string()
                                                               ^~~~
/home/rafael/src/Slicer-SOFA-gcc7/Release/SofaPython3/Testing/src/SofaPython3Testing/PythonTest.h:74:63: note: suggested alternative: ‘putw’
         return  std::to_string(p.index)+"_"+p.param.testgroup+path(p.param.filepath).stem().string()
                                                               ^~~~
                                                               putw
gmake[5]: *** [external_directories/SofaPython3/Testing/CMakeFiles/SofaPython3Testing.dir/src/SofaPython3Testing/PythonTest.cpp.o] Error 1
gmake[4]: *** [external_directories/SofaPython3/Testing/CMakeFiles/SofaPython3Testing.dir/all] Error 2
gmake[3]: *** [all] Error 2
gmake[2]: *** [Sofa-prefix/src/Sofa-stamp/Sofa-build] Error 2
gmake[1]: *** [CMakeFiles/Sofa.dir/all] Error 2
gmake: *** [all] Error 2
```