### PR TITLE
Add two testing features 

### DIFF
--- a/Testing/src/SofaPython3Testing/PythonTest.cpp
+++ b/Testing/src/SofaPython3Testing/PythonTest.cpp
@@ -119,7 +119,7 @@ void PythonTest::run( const PythonTestData& data )
             py::list testSuiteList = py::cast<py::list>(testSuite);
             if(!testSuiteList.size())
             {
-                msg_error() << "There doesn't seem to be any test in " << filename;
+                msg_warning() << "There doesn't seem to be any test in " << filename;
                 return ;
             }
 

--- a/Testing/src/SofaPython3Testing/PythonTestExtractor.cpp
+++ b/Testing/src/SofaPython3Testing/PythonTestExtractor.cpp
@@ -119,6 +119,7 @@ std::vector<PythonTestData> PythonTestExtractor::extract () const
         } catch(const std::exception& e) {
             msg_error("PythonTestExtractor") << "File skipped: " << (test.path+"/"+test.filename) << msgendl
                                         << e.what();
+            list.emplace_back(PythonTestData(filepath(test.path,test.filename), "loading_", {}));
         }
     }
 

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -384,3 +384,15 @@ def PrefabBuilder(f):
     SofaPrefabF.__dict__["__original__"] = f
     return SofaPrefabF
 
+def import_sofa_python_scene(path_to_scene : str):
+    """Return a python module containing a sofa scene"""
+    spec = importlib.util.spec_from_file_location("sofa.scene", path_to_scene)
+    foo = importlib.util.module_from_spec(spec)
+    sys.modules["module.name"] = foo
+    spec.loader.exec_module(foo)
+
+    if not hasattr(foo, "createScene"):
+        raise Exception("Unable to find 'createScene' in module "+path_to_scene)
+
+    return foo
+

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -385,11 +385,11 @@ def PrefabBuilder(f):
     return SofaPrefabF
 
 def import_sofa_python_scene(path_to_scene : str):
-    """Return a python module containing a sofa scene"""
-    spec = importlib.util.spec_from_file_location("sofa.scene", path_to_scene)
-    foo = importlib.util.module_from_spec(spec)
-    sys.modules["module.name"] = foo
-    spec.loader.exec_module(foo)
+    """Return a python module containing a SOFA scene"""
+    spec_from_location = importlib.util.spec_from_file_location("sofa.scene", path_to_scene)
+    module_name = importlib.util.module_from_spec(spec_from_location)
+    sys.modules["module.name"] = module_name
+    spec_from_location.loader.exec_module(module_name)
 
     if not hasattr(foo, "createScene"):
         raise Exception("Unable to find 'createScene' in module "+path_to_scene)

--- a/bindings/Sofa/tests/Core/Mass.py
+++ b/bindings/Sofa/tests/Core/Mass.py
@@ -1,4 +1,4 @@
-﻿# coding: utf8
+# coding: utf8
 
 import unittest
 import Sofa

--- a/examples/import_python_scene.py
+++ b/examples/import_python_scene.py
@@ -1,0 +1,16 @@
+import Sofa
+
+
+def createScene(root):
+	"""Demonstrates the use of Sofa.import_sofa_python_scene"""
+
+	# loads the python modules "liver.py"
+	liver = Sofa.import_sofa_python_scene("liver.py")
+
+	# Creates the scene and attach it to A 
+	a = root.addChild("A")
+	liver.createScene(a)
+	
+	# Feel free to add any other objects to the scene (eg: controllers manipulating something in the liver) 
+	...
+	


### PR DESCRIPTION
Feature 1: 
Currently when loading unittest (for python) into gtest (c++), a failure while loading the test in python does not generates a test failure which is problematic as load time error will be unnoticed.
The PR transform the loading of a python file containing unittest as real test in the gtest framework. The consequence is that a failure to load the file is not more ignored but reported as a gtest failure in the following way:
![image](https://github.com/user-attachments/assets/368df289-03da-4439-b89c-eaaf27f5abb6)

Feature 2:
Adds method import_sofa_python_scene(path_to_scene : str) in the python package Sofa
    
The introduced method loads dynamically python module containing a scene and returns it.    
This allows to do:
```python
scene = import_sofa_python_scene("myscene.py")
root = scene.createScene(Sofa.Core.Node("root"))
...
root.addObject(....)
```