### PR TITLE
Add cleanup to core and ensure that the cleanup happens in runSofa

### DIFF
--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -249,8 +249,15 @@ py::slice toSlice(const py::object& o)
 
 std::map<void*, std::pair<int, py::array>>& getObjectCache()
 {
-    static std::map<void*, std::pair<int, py::array>> s_objectcache {} ;
+    static std::map<void*, std::pair<int, py::array>>  s_objectcache{};
     return s_objectcache;
+}
+
+
+void clearCache()
+{
+    msg_info("SofaPython3") << "Clearing Sofa.Core cache...";
+    getObjectCache().clear();
 }
 
 void trimCache()

--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -194,6 +194,7 @@ SOFAPYTHON3_API std::string getPathTo(Base* b);
 SOFAPYTHON3_API const char* getFormat(const AbstractTypeInfo& nfo);
 
 SOFAPYTHON3_API std::map<void*, std::pair<int, pybind11::array>>& getObjectCache();
+SOFAPYTHON3_API void clearCache();
 SOFAPYTHON3_API void trimCache();
 
 SOFAPYTHON3_API bool hasArrayFor(BaseData* d);

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -482,6 +482,12 @@ void PythonEnvironment::addPluginManagerCallback()
             }
         }
     );
+    PluginManager::getInstance().addOnPluginCleanupCallbacks(pluginLibraryPath,
+        []()
+        {
+            PythonEnvironment::Release();
+        }
+    );
 }
 
 void PythonEnvironment::removePluginManagerCallback()

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <string>
 #include <sofa/helper/logging/FileInfo.h>
+#include <SofaPython3/DataHelper.h>
 
 /// Fixes compile errors:
 /// removing all slots macros is necessary if embedded in a Qt project

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -130,6 +130,10 @@ PYBIND11_MODULE(Core, core)
     moduleAddBaseMeshTopology(core);
     moduleAddPointSetTopologyModifier(core);
     moduleAddTaskScheduler(core);
+
+    //Make sure the cache is cleaned up when exiting the app
+    core.add_object("_cleanup", py::capsule([](){clearCache();}));
+
 }
 
 } ///namespace sofapython3


### PR DESCRIPTION
The "Release" method was never called when running python scene through runSofa, leading to non-correct cleanup of the python interpreter. 

This PR adds the cleanup callback and ensure that the data cache is deleted before the interpreter (in Sofa.Core)