### PR TITLE
Add new env.var to set a build configuration at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Setup SOFA and environment
         id: sofa
-        uses: fredroy/sofa-setup-action@v5-custom
+        uses: sofa-framework/sofa-setup-action@v5
         with:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Setup SOFA and environment
         id: sofa
-        uses: sofa-framework/sofa-setup-action@v5
+        uses: fredroy/sofa-setup-action@v5-custom
         with:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -105,7 +105,6 @@ if sofa_root and sys.platform == 'win32':
     sofapython3_bin_candidates = [sofapython3_bin_path] + sofapython3_bin_compilation_modes
 
     sofa_helper_dll = ["Sofa.Helper.dll", "Sofa.Helper_d.dll"]
-    
     sofa_file_test = ""
     for candidate in sofa_bin_candidates:
         for dll in sofa_helper_dll:

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -76,7 +76,19 @@ if sofa_root and sys.platform == 'win32':
     sofa_bin_path = os.path.join(sofa_root, "bin")
     sofapython3_bin_path = os.path.join(sofapython3_root, "bin")
 
-    compilation_modes = ["Release", "RelWithDebInfo", "Debug", "MinSizeRel"]
+    # A user using a build configuration could have a multiple-configuration type build
+    # which is typical on Windows and MSVC; and MacOS with XCode
+    # Previously the setup was arbitrarily choosing the first configuration it could find.
+    # Now, if the user set the env.var SOFA_BUILD_CONFIGURATION, he can choose a preferred configuration.
+    # If it is not found, it is considered as an error.
+    sofa_build_configuration = os.environ.get('SOFA_BUILD_CONFIGURATION')
+    compilation_modes = []
+    if sofa_build_configuration:
+        print("SOFA_BUILD_CONFIGURATION is set to " + sofa_build_configuration)
+        compilation_modes = [sofa_build_configuration]
+    else:
+        compilation_modes = ["Release", "RelWithDebInfo", "Debug", "MinSizeRel"] # Standard multi-configuration modes in CMake
+
     sofa_bin_compilation_modes = []
     sofapython3_bin_compilation_modes = []
     for mode in compilation_modes:
@@ -94,7 +106,7 @@ if sofa_root and sys.platform == 'win32':
     sofapython3_bin_candidates = [sofapython3_bin_path] + sofapython3_bin_compilation_modes
 
     sofa_helper_dll = ["Sofa.Helper.dll", "Sofa.Helper_d.dll"]
-
+    
     sofa_file_test = ""
     for candidate in sofa_bin_candidates:
         for dll in sofa_helper_dll:

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -78,8 +78,7 @@ if sofa_root and sys.platform == 'win32':
 
     # A user using a build configuration could have a multiple-configuration type build
     # which is typical on Windows and MSVC; and MacOS with XCode
-    # Previously the setup was arbitrarily choosing the first configuration it could find.
-    # Now, if the user set the env.var SOFA_BUILD_CONFIGURATION, he can choose a preferred configuration.
+    # If the user set the env.var SOFA_BUILD_CONFIGURATION, he can choose a preferred configuration.
     # If it is not found, it is considered as an error.
     sofa_build_configuration = os.environ.get('SOFA_BUILD_CONFIGURATION')
     compilation_modes = []


### PR DESCRIPTION
Title.

Sometimes it is frustrating with MSVC config that python3 interpreter choose a bad build directory for SOFA_ROOT because he just find the first build directory with Sofa.Helper.dll. So if you have both Release and RelWithDebInfo, it will always choose the first one, even if you are currenty working with the second one.
So this PR introduces a new envvar to force choose a configuration, called `SOFA_BUILD_CONFIGURATION`.
Actually it can also be useful if a user uses a custom name for the configuration type (other than release, relwithdebinfo, etc)

Note that this feature would be useful for macOS/XCode but for the moment SofaPython3 always considered macOS like Linux/{makefile/ninja}, i.e with a single configuration mode.