### PR TITLE
[Bindings] Remove static SofaInitializer, call unload into each respective module and clear cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,12 @@ jobs:
             echo "$WORKSPACE_ARTIFACT_PATH/lib" >> $GITHUB_PATH
             echo "$WORKSPACE_ARTIFACT_PATH/bin" >> $GITHUB_PATH
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/lib" | tee -a $GITHUB_ENV
             echo "DYLD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$DYLD_LIBRARY_PATH" | tee -a $GITHUB_ENV
+          else  # Linux
+            echo "SOFA_PLUGIN_PATH=$WORKSPACE_ARTIFACT_PATH/lib" | tee -a $GITHUB_ENV
+            echo "LD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
           fi
-          echo "LD_LIBRARY_PATH=$WORKSPACE_ARTIFACT_PATH/lib:$SOFA_ROOT/lib:$LD_LIBRARY_PATH" | tee -a $GITHUB_ENV
           echo "PYTHONPATH=$WORKSPACE_ARTIFACT_PATH/lib/python3/site-packages" | tee -a $GITHUB_ENV
           # Add execution right on the tests
           chmod +x $WORKSPACE_ARTIFACT_PATH/bin/*.Tests${{ steps.sofa.outputs.exe }}

--- a/Plugin/src/SofaPython3/DataHelper.cpp
+++ b/Plugin/src/SofaPython3/DataHelper.cpp
@@ -249,8 +249,15 @@ py::slice toSlice(const py::object& o)
 
 std::map<void*, std::pair<int, py::array>>& getObjectCache()
 {
-    static std::map<void*, std::pair<int, py::array>> s_objectcache {} ;
+    static std::map<void*, std::pair<int, py::array>>  s_objectcache{};
     return s_objectcache;
+}
+
+
+void clearCache()
+{
+    msg_info("SofaPython3") << "Clearing Sofa.Core cache...";
+    getObjectCache().clear();
 }
 
 void trimCache()

--- a/Plugin/src/SofaPython3/DataHelper.h
+++ b/Plugin/src/SofaPython3/DataHelper.h
@@ -194,6 +194,7 @@ SOFAPYTHON3_API std::string getPathTo(Base* b);
 SOFAPYTHON3_API const char* getFormat(const AbstractTypeInfo& nfo);
 
 SOFAPYTHON3_API std::map<void*, std::pair<int, pybind11::array>>& getObjectCache();
+SOFAPYTHON3_API void clearCache();
 SOFAPYTHON3_API void trimCache();
 
 SOFAPYTHON3_API bool hasArrayFor(BaseData* d);

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -324,7 +324,10 @@ void PythonEnvironment::Release()
 {
     /// Finish the Python Interpreter
     /// obviously can't use raii here
-    if(  Py_IsInitialized() ) {
+    static bool isReleased = false;
+    if(  Py_IsInitialized() && !isReleased) {
+        isReleased = true;
+
         PyGILState_Ensure();
         py::finalize_interpreter();
         getStaticData()->reset();

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -480,6 +480,12 @@ void PythonEnvironment::addPluginManagerCallback()
             }
         }
     );
+    PluginManager::getInstance().addOnPluginCleanupCallbacks(pluginLibraryPath,
+        []()
+        {
+            PythonEnvironment::Release();
+        }
+    );
 }
 
 void PythonEnvironment::removePluginManagerCallback()

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <string>
 #include <sofa/helper/logging/FileInfo.h>
+#include <SofaPython3/DataHelper.h>
 
 /// Fixes compile errors:
 /// removing all slots macros is necessary if embedded in a Qt project

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -51,6 +51,8 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Data/Binding_DataVectorString.h>
 #include <SofaPython3/Sofa/Core/Data/Binding_DataContainer.h>
 
+#include <sofa/core/init.h>
+
 namespace sofapython3
 {
 
@@ -130,6 +132,15 @@ PYBIND11_MODULE(Core, core)
     moduleAddBaseMeshTopology(core);
     moduleAddPointSetTopologyModifier(core);
     moduleAddTaskScheduler(core);
+
+    // called when the module is unloaded
+    auto atexit = py::module_::import("atexit");
+    atexit.attr("register")(py::cpp_function([]() {
+
+        sofa::core::cleanup();
+
+        msg_info("SofaPython3.Core") << "Sofa.Core unload()";
+    }));
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -137,10 +137,13 @@ PYBIND11_MODULE(Core, core)
     auto atexit = py::module_::import("atexit");
     atexit.attr("register")(py::cpp_function([]() {
 
+        clearCache();
+
         sofa::core::cleanup();
 
         msg_info("SofaPython3.Core") << "Sofa.Core unload()";
     }));
+
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -18,7 +18,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
-#include <sofa/core/init.h>
 #include <sofa/helper/init.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaPython3/PythonEnvironment.h>
@@ -108,7 +107,6 @@ static void parse_emitter_message_then(py::args args, const Action& action) {
 PYBIND11_MODULE(Helper, helper)
 {
     // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
-    sofa::core::init();
     sofa::helper::init();
 
     helper.doc() = R"doc(
@@ -155,6 +153,12 @@ PYBIND11_MODULE(Helper, helper)
     moduleAddMessageHandler(helper);
     moduleAddVector(helper);
     moduleAddSystem(helper);
+
+    auto atexit = py::module_::import("atexit");
+    atexit.attr("register")(py::cpp_function([]() {
+        sofa::helper::cleanup();
+        msg_info("SofaPython3.Helper") << "Sofa.Helper unload()";
+    }));
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -42,6 +42,7 @@ using sofa::simulation::Simulation;
 
 #include <sofa/core/init.h>
 #include <sofa/simulation/init.h>
+#include <sofa/simulation/common/init.h>
 #include <sofa/simulation/graph/init.h>
 
 namespace py = pybind11;
@@ -83,6 +84,17 @@ PYBIND11_MODULE(Simulation, simulation)
     {
         sofa::simulation::node::initTextures(n);
     });
+
+    // called when the module is unloaded
+    auto atexit = py::module_::import("atexit");
+    atexit.attr("register")(py::cpp_function([]() {
+
+        sofa::simulation::core::cleanup();
+        sofa::simulation::common::cleanup();
+        sofa::simulation::graph::cleanup();
+
+        msg_info("SofaPython3.Simulation") << "Sofa.Simulation unload()";
+    }));
 }
 
 } /// namespace sofapython3

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
@@ -72,23 +72,6 @@ using sofa::helper::logging::MainConsoleMessageHandler;
 namespace sofapython3
 {
 
-
-class SofaInitializer
-{
-public:
-    // TODO, ces trucs sont fort laid. Normalement ce devrait être une joli plugin qui
-    // appelle le init.
-    SofaInitializer(){
-        sofa::simulation::common::init();
-        sofa::simulation::graph::init();
-    }
-
-    ~SofaInitializer(){
-        sofa::simulation::common::cleanup();
-        sofa::simulation::graph::cleanup();
-    }
-};
-
 static std::vector<std::string>  getCategories(const std::string& className)
 {
     std::vector<std::string> categories;
@@ -108,8 +91,6 @@ static std::vector<std::string>  getCategories(const std::string& className)
     }
     return categories ;
 }
-
-static SofaInitializer s;
 
 /// The first parameter must be named the same as the module file to load.
 PYBIND11_MODULE(SofaRuntime, m) {
@@ -131,13 +112,6 @@ PYBIND11_MODULE(SofaRuntime, m) {
                    SofaRuntime.importPlugin("Sofa.Component.LinearSolver")
 
               )doc";
-
-    // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
-    sofa::core::init();
-    sofa::helper::init();
-    sofa::simulation::core::init();
-    sofa::simulation::graph::init();
-    sofa::simulation::common::init();
 
     // Add the plugin directory to PluginRepository
     const std::string& pluginDir = Utils::getExecutableDirectory();
@@ -198,6 +172,7 @@ PYBIND11_MODULE(SofaRuntime, m) {
     m.def("getCategories", &getCategories);
 
     addSubmoduleTimer(m);
+
 }
 
 }  // namespace sofapython3


### PR DESCRIPTION
Was
A small experiment (successful?) about unloading module when they themselves are unloaded~~
Also should help fix the shenanigans about #425 and https://github.com/sofa-framework/sofa/pull/4828

This PR:
- Fix #429 
- #425 
- in Windows/MSVC, fix quitting when using python3 as interpreter

output before:
```shell
$ python
Python 3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import Sofa
---------------------------------------
Checking SOFA_ROOT and SOFAPYTHON3_ROOT
Using environment variable SOFA_ROOT: D:\sofa\build\current
Warning: environment variable SOFAPYTHON3_ROOT is empty. Trying to guess it.
Guessed SOFAPYTHON3_ROOT: D:\sofa\build\current
Detected SOFA development build
Detected SofaPython3 development build
Found Sofa.Helper.dll in D:\sofa\build\current\bin\RelWithDebInfo
Found SofaPython3.dll in D:\sofa\build\current\bin\RelWithDebInfo
---------------------------------------
>>> quit()
[WARNING] [Sofa.Simulation.Graph] the library has not been cleaned up (sofa::simulation::graph::cleanup() has never been called, see sofa/helper/init.h)
[WARNING] [SofaSimulationCommon] the library has not been cleaned up (sofa::simulation::common::cleanup() has never been called, see sofa/helper/init.h)
[WARNING] [SofaSimulationCore] the library has not been cleaned up (sofa::simulation::core::cleanup() has never been called, see sofa/helper/init.h)
[WARNING] [SofaCore] the library has not been cleaned up (sofa::core::cleanup() has never been called, see sofa/helper/init.h)
[WARNING] [SofaDefaultType] the library has not been cleaned up (sofa::defaulttype::cleanup() has never been called, see sofa/helper/init.h)
[WARNING] [SofaHelper] the library has not been cleaned up (sofa::helper::cleanup() has never been called, see sofa/helper/init.h)
````
output after:
```shell
$ python
Python 3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import Sofa
---------------------------------------
Checking SOFA_ROOT and SOFAPYTHON3_ROOT
Using environment variable SOFA_ROOT: D:\sofa\build\current
Warning: environment variable SOFAPYTHON3_ROOT is empty. Trying to guess it.
Guessed SOFAPYTHON3_ROOT: D:\sofa\build\current
Detected SOFA development build
Detected SofaPython3 development build
Found Sofa.Helper.dll in D:\sofa\build\current\bin\RelWithDebInfo
Found SofaPython3.dll in D:\sofa\build\current\bin\RelWithDebInfo
---------------------------------------
>>> quit()
[INFO]    [SofaPython3.Simulation] Sofa.Simulation unload()
[INFO]    [SofaPython3.Core] Sofa.Core unload()
[INFO]    [SofaPython3.Helper] Sofa.Helper unload()
```



Thanks to https://pybind11.readthedocs.io/en/stable/advanced/misc.html#module-destructors
