### PR TITLE
[SofaRuntime] Check if numpy and/or scipy (optional) are available

### DIFF
--- a/bindings/SofaRuntime/package/__init__.py
+++ b/bindings/SofaRuntime/package/__init__.py
@@ -18,6 +18,21 @@ import importlib
 ###################### MODULES INPORTS & UNLOAD FEATURES ######################
 ###############################################################################
 
+
+try:
+    import numpy
+except ModuleNotFoundError as error:
+    Sofa.msg_error("SofaRuntime",str(error))
+    Sofa.msg_error("SofaRuntime", 'numpy is mandatory for SofaPython3')
+    sys.exit(1)
+
+try:
+    import scipy
+except ModuleNotFoundError as error:
+    Sofa.msg_warning("SofaRuntime",str(error))
+    Sofa.msg_warning("SofaRuntime", "scipy is strongly recommended for SofaPython3")
+    pass
+
 # Keep a list of the modules always imported in the Sofa-PythonEnvironment
 try:
     __SofaPythonEnvironment_importedModules__


### PR DESCRIPTION
Clean way to warn the user to install numpy (and maybe scipy)