### PR TITLE
Update PythonEnvironment regarding GIL deprecation

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -193,8 +193,6 @@ void PythonEnvironment::Init()
         static const PyThreadState* init = PyEval_SaveThread(); (void) init;
     }
 
-    PyEval_InitThreads();
-
     // Required for sys.path, used in addPythonModulePath().
     executePython([]{ PyRun_SimpleString("import sys");});
 


### PR DESCRIPTION
The GIL is initialized by `Py_Initialize()` since Python 3.7 (called earlier)