### PR TITLE
Display attribute_error with msg_error

### DIFF
--- a/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
@@ -133,7 +133,7 @@ void SceneLoaderPY3::loadSceneWithArguments(const char *filename,
         ss << "Unable to completely load the scene from file '"<< filename << "'." << msgendl
             << "Python exception: " << msgendl
             << "  " << e.what();
-        if( py::isinstance(e.type(), py::eval("type(DeprecationWarning)")) )
+        if( py::isinstance(e.type(), py::eval("type(DeprecationWarning)")) && !py::isinstance(e.type(), py::eval("type(AttributeError)")))
         {
             msg_deprecated() << ss.str();
         }else


### PR DESCRIPTION
When using a wrong attribute to an object,  the error message is printed with a "Deprecation" status 
```
[DEPRECATED] [SofaPython3::SceneLoader] Unable to completely load the scene from file '/Users/fred/Work/sofa/SofaLnRobotics/scenes/demos/Demo_05_simple_data_inverse.py'.
Python exception:
  AttributeError: Unable to find attribute: EdgeSetTopologyContainer
   You possibly wanted to access:
   - The object named 'EdgeSetTopologyModifier' (80% match)
```

it seems that the "AttributeError" exception from pybind is also a "DeprecationWarning" apparently ?? 🤔 (according to the test)
so this PR tests if the exception is a DeprecationWarning and NOT an AttributeError  to display as "deprecated"

Result:
```
[ERROR]   [SofaPython3::SceneLoader] Unable to completely load the scene from file '/Users/fred/Work/sofa/SofaLnRobotics/scenes/demos/Demo_05_simple_data_inverse.py'.
Python exception:
  AttributeError: Unable to find attribute: EdgeSetTopologyContainer
   You possibly wanted to access:
   - The object named 'EdgeSetTopologyModifier' (80% match)

```