### PR TITLE
[Sofa.Gui] Add dependant option to not bind qt/qglviewer to Sofa.Gui (even if present)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ endif()
 sofa_find_package(Sofa.Component.IO.Mesh QUIET)
 CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAEXPORTER "Bind the SOFA exporter component." ON "Sofa.Component.IO.Mesh_FOUND" OFF)
 
+
+sofa_find_package(Sofa.GUI.Common QUIET)
+CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAGUI "Bind the SOFA exporter component." ON "Sofa.GUI.Common_FOUND" OFF)
+
+
 # BUILD OPTIONS
 if (NOT SP3_COMPILED_AS_SUBPROJECT)
     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAEXPORTER "Bind the SOFA exporter component."
 
 
 sofa_find_package(Sofa.GUI.Common QUIET)
-CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAGUI "Bind the SOFA exporter component." ON "Sofa.GUI.Common_FOUND" OFF)
+CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAGUI "Bind the SOFA gui component." ON "Sofa.GUI.Common_FOUND" OFF)
 
 
 # BUILD OPTIONS

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -2,8 +2,7 @@ project(Bindings)
 
 set(BINDINGS_MODULE_LIST Sofa SofaRuntime SofaTypes Modules)
 
-sofa_find_package(Sofa.GUI.Common QUIET)
-if(Sofa.GUI.Common_FOUND)
+if(SP3_WITH_SOFAGUI)
     list(APPEND BINDINGS_MODULE_LIST SofaGui)
 endif()
 

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,6 +1,12 @@
 project(Bindings)
 
-set(BINDINGS_MODULE_LIST Sofa SofaRuntime SofaGui SofaTypes Modules)
+set(BINDINGS_MODULE_LIST Sofa SofaRuntime SofaTypes Modules)
+
+sofa_find_package(Sofa.GUI.Common QUIET)
+if(Sofa.GUI.Common_FOUND)
+    list(APPEND BINDINGS_MODULE_LIST SofaGui)
+endif()
+
 if(SP3_WITH_SOFAEXPORTER)
     list(APPEND BINDINGS_MODULE_LIST SofaExporter)
 endif()
@@ -24,6 +30,7 @@ if(UNIX)
         set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     endif()
 endif()
+
 
 foreach(bindings_module ${BINDINGS_MODULE_LIST})
     add_subdirectory(${bindings_module})

--- a/bindings/SofaGui/CMakeLists.txt
+++ b/bindings/SofaGui/CMakeLists.txt
@@ -16,15 +16,20 @@ sofa_find_package(Sofa.Core REQUIRED)
 sofa_find_package(Sofa.GUI.Common REQUIRED) # to get the GUI mechanism
 
 sofa_find_package(Sofa.GUI.Batch QUIET)
-if(Sofa.GUI.Batch_FOUND)
+CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAGUIBATCH "Enable the SOFA batch gui component." ON "Sofa.GUI.Batch_FOUND" OFF)
+if(Sofa.GUI.Batch_FOUND AND SP3_WITH_SOFAGUIBATCH)
      list(APPEND SUPPORTED_GUIS Sofa.GUI.Batch)
 endif()
+
 sofa_find_package(Sofa.GUI.Qt QUIET)
-if(Sofa.GUI.Qt_FOUND)
+CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAGUIQT "Enable the SOFA Qt gui component." ON "Sofa.GUI.Qt_FOUND" OFF)
+if(Sofa.GUI.Qt_FOUND AND SP3_WITH_SOFAGUIQT)
      list(APPEND SUPPORTED_GUIS Sofa.GUI.Qt)
 endif()
+
 sofa_find_package(Sofa.GUI.HeadlessRecorder QUIET)
-if(Sofa.GUI.HeadlessRecorder_FOUND)
+CMAKE_DEPENDENT_OPTION(SP3_WITH_SOFAGUIHEADLESSRECORDER "Enable the SOFA HeadlessRecorder gui component." ON "Sofa.GUI.HeadlessRecorder_FOUND" OFF)
+if(Sofa.GUI.HeadlessRecorder_FOUND AND SP3_WITH_SOFAGUIHEADLESSRECORDER)
      list(APPEND SUPPORTED_GUIS Sofa.GUI.HeadlessRecorder)
 endif()
 


### PR DESCRIPTION
Based on 
- #409 

Title says all.

IMO, we should never load Sofa.Gui.Qt and Sofa.Gui.QglViewer implicitly and do similarly to runSOFA, aka load the modules on demand (like Sofa.ImGui). 
But this PR is behaviorally(?) compatible with current scenes and binaries: if you dont switch-off the dependant options, it will still be implicitly loaded.