### PR TITLE
Use PyMem_RawFree when resetting PythonEnvironmentData

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -92,7 +92,7 @@ public:
     void reset()
     {
         for(auto s : m_argv){
-            PyMem_Free(s);
+            PyMem_RawFree(s);
         }
         m_argv.clear();
         addedPath.clear();


### PR DESCRIPTION
runSofa + SofaPython3 is crashing when quitting (since I dont know when) ?
After investigation, PyMem_Free is called without GIL, which is illegal.

https://github.com/python/cpython/issues/105690

I guess this behavior started when clearing the env when unloading (https://github.com/sofa-framework/SofaPython3/pull/432), plus python 3.12

Instead we must call `PyMem_RawFree` which allows us to delete non-obj (our case) without the gil.




PS1: the whole PySys_SetArgvEx stuff is deprecated and will need  a rewrite.
PS2: I am skeptical about the needs to store the m_argv, etc 🤔