### PR TITLE
Add stubgen autogeneration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,23 @@ jobs:
             echo ${CCACHE_BASEDIR}
             ccache -s
           fi
-        
+
+      - name: Generate stubfiles
+        shell: bash
+        run: |
+          
+          #Install stubgen
+          ${{ steps.sofa.outputs.python_exe }} -m pip install mypy
+          
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            cmd //c "${{ steps.sofa.outputs.vs_vsdevcmd }} \
+              && cd /d ${{ env.WORKSPACE_INSTALL_PATH }}/lib/python3/site-packages/ \
+              && bash ${{ env.WORKSPACE_SRC_PATH }}/scripts/generate_stubs.sh ${{ env.WORKSPACE_INSTALL_PATH }}/lib/python3/site-packages/
+          else
+            cd ${{ env.WORKSPACE_INSTALL_PATH }}/lib/python3/site-packages/
+            /bin/bash ${{ env.WORKSPACE_SRC_PATH }}/scripts/generate_stubs.sh ${{ env.WORKSPACE_INSTALL_PATH }}/lib/python3/site-packages/
+          fi
+
       - name: Set env vars for artifacts
         shell: bash
         run: |

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -49,6 +49,20 @@ sofa_create_component_in_package_with_targets(
     TARGETS ${PROJECT_NAME}
     )
 
+option(SP3_GENERATE_STUBS "Generate stub files at install step required for auto-completion" OFF)
+if(SP3_GENERATE_STUBS)
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+        set(bash_name bash)
+    else ()
+        set(bash_name /bin/bash)
+    endif ()
+    add_custom_target(GenerateStubs ALL ${bash_name} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_stubs.sh ${CMAKE_BUILD_DIR}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${SP3_PYTHON_PACKAGES_DIRECTORY}/
+        COMMENT "Generating stub files"
+    )
+    add_dependencies(GenerateStubs ${PROJECT_NAME})
+endif()
+
 #if (SP3_COMPILED_AS_SOFA_SUBPROJECT)
 #    ## Python configuration file (build tree), the lib in the source dir (easier while developping .py files)
 #    file(WRITE "${CMAKE_BINARY_DIR}/etc/sofa/python.d/plugin.SofaPython3.bindings" "${CMAKE_BINARY_DIR}/${SP3_PYTHON_PACKAGES_DIRECTORY}\n")

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -49,20 +49,6 @@ sofa_create_component_in_package_with_targets(
     TARGETS ${PROJECT_NAME}
     )
 
-option(SP3_GENERATE_STUBS "Generate stub files at install step required for auto-completion" OFF)
-if(SP3_GENERATE_STUBS)
-    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-        set(bash_name bash)
-    else ()
-        set(bash_name /bin/bash)
-    endif ()
-    add_custom_target(GenerateStubs ALL ${bash_name} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_stubs.sh ${CMAKE_BUILD_DIR}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${SP3_PYTHON_PACKAGES_DIRECTORY}/
-        COMMENT "Generating stub files"
-    )
-    add_dependencies(GenerateStubs ${PROJECT_NAME})
-endif()
-
 #if (SP3_COMPILED_AS_SOFA_SUBPROJECT)
 #    ## Python configuration file (build tree), the lib in the source dir (easier while developping .py files)
 #    file(WRITE "${CMAKE_BINARY_DIR}/etc/sofa/python.d/plugin.SofaPython3.bindings" "${CMAKE_BINARY_DIR}/${SP3_PYTHON_PACKAGES_DIRECTORY}\n")

--- a/scripts/generate_stubs.sh
+++ b/scripts/generate_stubs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+for module_name in *; do
+    echo "Generating stubgen for $module_name"
+    stubgen -p $module_name --include-docstrings  --inspect-mode
+    if [ -d "./out/$module_name/" ]; then
+      rsync -a ./out/$module_name/ ./$module_name/
+    fi
+    rm -rf ./out
+done

--- a/scripts/generate_stubs.sh
+++ b/scripts/generate_stubs.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+usage() {
+    echo "Usage: generate_stubs.sh <sofa-python3-site-packages-dir> "
+    echo "This script automatically generates stub files for SofaPython3 modules"
+}
+
+if [ "$#" -eq 1 ]; then
+    WORK_DIR=$1
+else
+    usage; exit 1
+fi
+
+cd $WORK_DIR
+
+
 for module_name in *; do
     echo "Generating stubgen for $module_name"
     stubgen -p $module_name --include-docstrings  --inspect-mode


### PR DESCRIPTION
Tried to do it during the build (see first commit). But because ninja offers no guaranty over the dependency effective termination (see https://cmake.org/cmake/help/latest/command/add_dependencies.html#command:add_dependencies) it doesn't work. 

Tried to do it through a `add_custom_command` but it isn't possible because the targets SofaPython3 and Bindings are Interfaces. 

Also tried to do it during the install process which is a nightmare because the installation order isn't ordered.

So back to the weak solution, a script that needs to be run by hands. I'll really enjoy adding it to Jenkins...  