### PR TITLE
Fix missing name in ClassEntry Binding_ObjectFactory.cpp

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
@@ -169,9 +169,11 @@ py::dict dataAlias(const ObjectFactory::ClassEntry &self)
 
 
 void moduleAddObjectFactory(py::module &m) {
-    py::class_<ObjectFactory> factory (m, "ObjectFactory", sofapython3::doc::objectmodel::ObjectFactoryClass);
+    py::class_<ObjectFactory> factory (m, "ObjectFactory",
+                                       sofapython3::doc::objectmodel::ObjectFactoryClass);
 
-    py::class_<ObjectFactory::ClassEntry> entry(m, sofapython3::doc::objectmodel::ClassEntryClass);
+    py::class_<ObjectFactory::ClassEntry> entry(m, "ClassEntry",
+                                                sofapython3::doc::objectmodel::ClassEntryClass);
     entry.def_property_readonly("className", &className);
     entry.def_property_readonly("aliases", &aliases);
     entry.def_property_readonly("description", &description);


### PR DESCRIPTION
NB: this makes subgen fails because of an  "empty" name. 