### PR TITLE
[Simulation] Add initRoot binding

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -62,6 +62,7 @@ PYBIND11_MODULE(Simulation, simulation)
     simulation.def("print", [](Node* n){ sofa::simulation::node::print(n); }, sofapython3::doc::simulation::print);
     simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::node::animate(n, dt); },sofapython3::doc::simulation::animate);
     simulation.def("init", [](Node* n){ sofa::simulation::node::init(n); }, sofapython3::doc::simulation::init);
+    simulation.def("initRoot", [](Node* n){ sofa::simulation::node::initRoot(n); }, sofapython3::doc::simulation::initRoot);
     simulation.def("initVisual", [](Node* n){ n->getVisualLoop()->initStep(sofa::core::visual::VisualParams::defaultInstance()); }, sofapython3::doc::simulation::initVisual);
     simulation.def("reset", [](Node* n){ sofa::simulation::node::reset(n); }, sofapython3::doc::simulation::reset);
   

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation_doc.h
@@ -47,7 +47,12 @@ static auto print =
 
 static auto init =
         R"(
-        Initialize the objects
+        Initialize the objects in the specified node
+        )";
+
+static auto initRoot =
+        R"(
+        Initialize from the root node
         )";
 
 static auto initVisual =


### PR DESCRIPTION
Not sure why it was not here before 🤔
as initRoot(root) does different things than init(root)

On my side using directly python with imgui (on macos), this fixes the rendering at startup (as the bbox is not computed initially without initRoot).

Actually, all the scenes which are run using directly python should use initRoot (to be consistent with runSofa)