### PR TITLE
[examples] Use initRoot instead of init

### DIFF
--- a/examples/ReadTheDocs_Example.py
+++ b/examples/ReadTheDocs_Example.py
@@ -15,7 +15,7 @@ def createScene(rootNode):
 
         rootNode.bbox = [[-1, -1, -1],[1,1,1]]
 
-        rootNode.addObject("RequiredPlugin", pluginName=[        'Sofa.Component.AnimationLoop',
+        rootNode.addObject("RequiredPlugin", pluginName=['Sofa.Component.AnimationLoop',
         'Sofa.Component.Collision.Detection.Algorithm',
         'Sofa.Component.Collision.Detection.Intersection',
         'Sofa.Component.Collision.Geometry',

--- a/examples/additional-examples/ControllerScene.py
+++ b/examples/additional-examples/ControllerScene.py
@@ -119,7 +119,7 @@ def main():
     # Create and initialize the scene
     root = Sofa.Core.Node()
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     # Run simulation
     for i in range(0, 360):

--- a/examples/additional-examples/pygame_example.py
+++ b/examples/additional-examples/pygame_example.py
@@ -100,7 +100,7 @@ def createScene(root):
 if __name__ == '__main__':
     root = Sofa.Core.Node("myroot")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
     init_display(root)
     try:
         while True:

--- a/examples/additional-examples/pyqt_example.py
+++ b/examples/additional-examples/pyqt_example.py
@@ -143,7 +143,7 @@ class SofaSim():
 
     def init_sim(self):
         # start the simulator
-        Sofa.Simulation.init(self.root)
+        Sofa.Simulation.initRoot(self.root)
 
     def step_sim(self):
         self.visuals.camera.position = self.visuals.camera.position + [-0.0002, 0, 0]

--- a/examples/advanced_timer.py
+++ b/examples/advanced_timer.py
@@ -89,7 +89,7 @@ def createScene(root):
 def main():
     root = Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     # Run the simulation for 5 steps
     for iteration in range(5):

--- a/examples/basic-addGUI.py
+++ b/examples/basic-addGUI.py
@@ -15,7 +15,7 @@ def main():
     root = Sofa.Core.Node("root")
     # Call the below 'createScene' function to create the scene graph
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     if not USE_GUI:
         for iteration in range(10):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -12,7 +12,7 @@ def main():
     createScene(root)
 
     # Once defined, initialization of the scene graph
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     # Run the simulation for 10 steps
     for iteration in range(10):

--- a/examples/emptyController.py
+++ b/examples/emptyController.py
@@ -99,6 +99,7 @@ def main():
 
     root=Sofa.Core.Node("root")
     createScene(root)
+    Sofa.Simulation.initRoot(root)
 
     Sofa.Gui.GUIManager.Init("myscene", "qglviewer")
     Sofa.Gui.GUIManager.createGUI(root, __file__)

--- a/examples/emptyDataEngine.py
+++ b/examples/emptyDataEngine.py
@@ -36,7 +36,7 @@ def main():
 
     root=Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     Sofa.Gui.GUIManager.Init("myscene", "qglviewer")
     Sofa.Gui.GUIManager.createGUI(root, __file__)

--- a/examples/emptyForceField.py
+++ b/examples/emptyForceField.py
@@ -61,7 +61,7 @@ def main():
 
     root=Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     Sofa.Gui.GUIManager.Init("myscene", "qglviewer")
     Sofa.Gui.GUIManager.createGUI(root, __file__)

--- a/examples/example-forcefield.py
+++ b/examples/example-forcefield.py
@@ -63,7 +63,7 @@ def main():
 
     root=Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     Sofa.Gui.GUIManager.Init("myscene", "qglviewer")
     Sofa.Gui.GUIManager.createGUI(root, __file__)

--- a/examples/liver-scriptcontroller.py
+++ b/examples/liver-scriptcontroller.py
@@ -12,7 +12,7 @@ def main():
 
     root = Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     if not USE_GUI:
         for iteration in range(10):

--- a/examples/liver.py
+++ b/examples/liver.py
@@ -12,7 +12,7 @@ def main():
 
     root = Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     if not USE_GUI:
         for iteration in range(10):

--- a/examples/loadXMLfromPython.py
+++ b/examples/loadXMLfromPython.py
@@ -34,7 +34,7 @@ def main():
 
 	root = Sofa.Core.Node("root")
 	createScene(root)
-	Sofa.Simulation.init(root)
+	Sofa.Simulation.initRoot(root)
 
 	# Find out the supported GUIs
 	print ("Supported GUIs are: " + Sofa.Gui.GUIManager.ListSupportedGUI(","))

--- a/examples/springForceField.py
+++ b/examples/springForceField.py
@@ -18,7 +18,6 @@ def createScene(root):
     ])
 
 
-
     root.addObject('DefaultAnimationLoop')
 
     surface_node = root.addChild('Surface')

--- a/examples/taskScheduler.py
+++ b/examples/taskScheduler.py
@@ -33,7 +33,7 @@ def createScene(root):
 def main():
     root = Sofa.Core.Node("root")
     createScene(root)
-    Sofa.Simulation.init(root)
+    Sofa.Simulation.initRoot(root)
 
     for nb_threads in range(1, TaskScheduler.GetHardwareThreadsCount() + 1):
         print(f'Number of threads #{nb_threads}')


### PR DESCRIPTION
Since https://github.com/sofa-framework/SofaPython3/pull/457, the `init()` function does not trigger the `computeBbox`. The `initRoot()` does it since it is a specific initialization for the root node.

See typical discussion: https://github.com/sofa-framework/sofa/discussions/5174