### PR TITLE
Fix bindings cmake config for missing simpleApi

### DIFF
--- a/bindings/Sofa/Bindings.SofaConfig.cmake.in
+++ b/bindings/Sofa/Bindings.SofaConfig.cmake.in
@@ -14,6 +14,7 @@ find_package(Sofa.Simulation.Core QUIET REQUIRED)
 # Required by Bindings.Sofa.Core
 find_package(Sofa.Component.Visual QUIET REQUIRED)
 find_package(Sofa.Component.Collision.Response.Contact QUIET REQUIRED)
+find_package(Sofa.SimpleApi QUIET REQUIRED)
 
 # Required by Bindings.Sofa.Simulation
 find_package(Sofa.Simulation.Graph QUIET REQUIRED)


### PR DESCRIPTION
As suggested by @alxbilger in https://github.com/SofaDefrost/SoftRobots.Inverse/pull/53 , thanks for the fix.
This adds the missing dependency to `Sofa.SimpleApi` for `Bindings.Sofa` cmake config file.

I'm waiting the conda CI to validate it fixes the problem on `SoftRobots.Inverse` and will mark as ready to review if succeeds.