### PR TITLE
[Bindings.Helper] Add bindings to retrieve config directories

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.cpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+
+#include <SofaPython3/Sofa/Helper/Binding_Utils.h>
+#include <SofaPython3/PythonFactory.h>
+
+#include <sofa/helper/Utils.h>
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+namespace sofapython3
+{
+    
+void moduleAddUtils(py::module &m) {
+    py::class_<sofa::helper::Utils> utils(m, "Utils");
+    utils.doc() = "Utility class with convenient functions.";
+
+    const auto GetSofaUserLocalDirectoryDoc = R"doc(
+        Get the directory where is stored the sofa configuration.
+    )doc";
+    utils.def_static("GetSofaUserLocalDirectory", &sofa::helper::Utils::getSofaUserLocalDirectory, GetSofaUserLocalDirectoryDoc);
+    
+    const auto GetSofaDataDirectoryDoc = R"doc(
+        Get the directory where is stored the sofa output data such as screenshots.
+    )doc";
+    utils.def_static("GetSofaDataDirectory", &sofa::helper::Utils::getSofaDataDirectory, GetSofaDataDirectoryDoc);
+}
+
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.h
@@ -1,0 +1,30 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3
+{
+
+    void moduleAddUtils(pybind11::module &m);
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(Bindings.Sofa.Helper)
 
 set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Vector.h
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Submodule_System.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_MessageHandler.h
@@ -10,6 +11,7 @@ set(HEADER_FILES
 set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Helper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_MessageHandler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Vector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Submodule_System.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Binding_FileRepository.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -25,6 +25,7 @@
 #include <SofaPython3/Sofa/Helper/System/Submodule_System.h>
 #include <SofaPython3/Sofa/Helper/Binding_MessageHandler.h>
 #include <SofaPython3/Sofa/Helper/Binding_Vector.h>
+#include <SofaPython3/Sofa/Helper/Binding_Utils.h>
 
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
@@ -151,6 +152,7 @@ PYBIND11_MODULE(Helper, helper)
     moduleAddMessageHandler(helper);
     moduleAddVector(helper);
     moduleAddSystem(helper);
+    moduleAddUtils(helper);
 
     auto atexit = py::module_::import("atexit");
     atexit.attr("register")(py::cpp_function([]() {


### PR DESCRIPTION
It allows to write
`Sofa.Gui.BaseGUI.SetConfigDirectoryPath(os.path.join(Sofa.Helper.Utils.GetSofaUserLocalDirectory(), 'config'), True)`

similarly to runSofa

`BaseGUI::setConfigDirectoryPath(FileSystem::append(Utils::getSofaUserLocalDirectory(), "config"), true);`
    

Useful to centralize the config file for both runSofa or pure-python scenes