### PR TITLE
Add a function to get the kinetic and potential energy of a node from a python script

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -22,6 +22,7 @@
 #include <pybind11/numpy.h>
 
 #include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/mechanicalvisitor/MechanicalComputeEnergyVisitor.h>
 #include <sofa/core/ComponentNameHelper.h>
 
 #include <sofa/core/objectmodel/BaseData.h>
@@ -606,6 +607,14 @@ void sendEvent(Node* self, py::object pyUserData, char* eventName)
     self->propagateEvent(sofa::core::execparams::defaultInstance(), &event);
 }
 
+py::object computeEnergy(Node* self)
+{
+    m_energyVisitor   = new sofa::simulation::mechanicalvisitor::MechanicalComputeEnergyVisitor(core::mechanicalparams::defaultInstance());
+    m_energyVisitor->execute(self->getContext());
+    kineticEnergy = m_energyVisitor->getKineticEnergy();
+    potentialEnergy = m_energyVisitor->getPotentialEnergy();
+    delete m_energyVisitor;
+    return py::cast(std::make_tuple(kineticEnergu, potentialEnergy));
 }
 
 void moduleAddNode(py::module &m) {
@@ -660,6 +669,7 @@ void moduleAddNode(py::module &m) {
     p.def("getMechanicalState", &getMechanicalState, sofapython3::doc::sofa::core::Node::getMechanicalState);
     p.def("getMechanicalMapping", &getMechanicalMapping, sofapython3::doc::sofa::core::Node::getMechanicalMapping);
     p.def("sendEvent", &sendEvent, sofapython3::doc::sofa::core::Node::sendEvent);
+    p.def("computeEnergy", &computeEnergy, sofapython3::doc::sofa::core::Node::computeEnergy);
 
 }
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -609,12 +609,13 @@ void sendEvent(Node* self, py::object pyUserData, char* eventName)
 
 py::object computeEnergy(Node* self)
 {
-    m_energyVisitor   = new sofa::simulation::mechanicalvisitor::MechanicalComputeEnergyVisitor(core::mechanicalparams::defaultInstance());
-    m_energyVisitor->execute(self->getContext());
-    kineticEnergy = m_energyVisitor->getKineticEnergy();
-    potentialEnergy = m_energyVisitor->getPotentialEnergy();
-    delete m_energyVisitor;
-    return py::cast(std::make_tuple(kineticEnergu, potentialEnergy));
+    sofa::simulation::mechanicalvisitor::MechanicalComputeEnergyVisitor energyVisitor(sofa::core::mechanicalparams::defaultInstance());
+    energyVisitor.execute(self->getContext());
+    const SReal kineticEnergy = energyVisitor.getKineticEnergy();
+    const SReal potentialEnergy = energyVisitor.getPotentialEnergy();
+    return py::cast(std::make_tuple(kineticEnergy, potentialEnergy));
+}
+
 }
 
 void moduleAddNode(py::module &m) {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -397,6 +397,10 @@ static auto sendEvent =
         :type pyUserData: py::object
         :type eventName: string
         )";
+static auto computeEnergy =
+        R"(
+        Returns the tuple (kineticEnergy, potentialEnergy)
+        )";
 
 }
 


### PR DESCRIPTION
As suggested by @alxbilger [here](https://github.com/sofa-framework/sofa/discussions/2702#discussioncomment-11583071)

Also adapted from QEnergyStatWidget in Sofa.Qt.

I did not manage to build this yet on my machine, so I haven't tested it.