### PR TITLE
Introduce bindings for SceneCheck

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheck.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheck.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaPython3/Sofa/Simulation/Binding_SceneCheck.h>
+#include <SofaPython3/Sofa/Simulation/Binding_SceneCheck_doc.h>
+#include <sofa/simulation/SceneCheck.h>
+
+namespace sofapython3
+{
+
+namespace py { using namespace pybind11; }
+
+void moduleAddSceneCheck(pybind11::module &m)
+{
+    // create a python binding for the C++ class LinearSpring from SofaDeformable
+    py::class_<sofa::simulation::SceneCheck, std::shared_ptr<sofa::simulation::SceneCheck>> s
+    (m, "SceneCheck", sofapython3::doc::simulation::SceneCheckClass);
+
+    s.def("getName", &sofa::simulation::SceneCheck::getName, sofapython3::doc::simulation::SceneCheck_getName);
+    s.def("getDesc", &sofa::simulation::SceneCheck::getDesc, sofapython3::doc::simulation::SceneCheck_getDesc);
+}
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheck.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheck.h
@@ -1,0 +1,28 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddSceneCheck(pybind11::module& m);
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#include <SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry.h>
+#include <SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry_doc.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+#include <pybind11/stl.h>
+
+namespace sofapython3
+{
+
+namespace py { using namespace pybind11; }
+
+void moduleAddSceneCheckMainRegistry(pybind11::module &m)
+{
+    py::class_<sofa::simulation::SceneCheckMainRegistry> registry (m, "SceneCheckMainRegistry",
+        sofapython3::doc::simulation::SceneCheckMainRegistryClass);
+
+    registry.def_static("getRegisteredSceneChecks",
+        []() {
+            return std::vector(sofa::simulation::SceneCheckMainRegistry::getRegisteredSceneChecks());
+        },
+        sofapython3::doc::simulation::SceneCheckMainRegistry_getRegisteredSceneChecks);
+}
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry.h
@@ -1,0 +1,28 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddSceneCheckMainRegistry(pybind11::module& m);
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry_doc.h
@@ -1,0 +1,28 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+namespace sofapython3::doc::simulation
+{
+
+static auto SceneCheckMainRegistryClass = "The main registry containing verification checks on a scene.";
+static auto SceneCheckMainRegistry_getRegisteredSceneChecks = "Returns all the verification checks registered into the main registry.";
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheck_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Binding_SceneCheck_doc.h
@@ -1,0 +1,30 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+namespace sofapython3::doc::simulation
+{
+
+static auto SceneCheckClass = "A verification check on a scene.";
+
+static auto SceneCheck_getName = "Returns the name of the verification check.";
+static auto SceneCheck_getDesc = "Returns the description of the verification check.";
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
@@ -2,10 +2,16 @@ project(Bindings.Sofa.Simulation)
 
 set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Simulation_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SceneCheck.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SceneCheck_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SceneCheckMainRegistry.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SceneCheckMainRegistry_doc.h
 )
 
 set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Submodule_Simulation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SceneCheck.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_SceneCheckMainRegistry.cpp
 )
 
 if (NOT TARGET SofaPython3::Plugin)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -39,6 +39,8 @@ using sofa::simulation::Simulation;
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/VisualLoop.h>
 #include <SofaPython3/Sofa/Simulation/Submodule_Simulation_doc.h>
+#include <SofaPython3/Sofa/Simulation/Binding_SceneCheck.h>
+#include <SofaPython3/Sofa/Simulation/Binding_SceneCheckMainRegistry.h>
 
 #include <sofa/core/init.h>
 #include <sofa/simulation/init.h>
@@ -58,6 +60,9 @@ PYBIND11_MODULE(Simulation, simulation)
     sofa::simulation::graph::init();
 
     simulation.doc() =sofapython3::doc::simulation::Class;
+
+    moduleAddSceneCheck(simulation);
+    moduleAddSceneCheckMainRegistry(simulation);
 
     simulation.def("print", [](Node* n){ sofa::simulation::node::print(n); }, sofapython3::doc::simulation::print);
     simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::node::animate(n, dt); },sofapython3::doc::simulation::animate);

--- a/examples/scene_check.py
+++ b/examples/scene_check.py
@@ -1,0 +1,39 @@
+import Sofa
+import SofaRuntime
+
+def main():
+    # Make sure to load all necessary libraries
+    SofaRuntime.importPlugin("Sofa.Component.StateContainer")
+    # This is important to register the scene checks contained in this plugin into the registry
+    SofaRuntime.importPlugin("SceneChecking")
+
+    for scene_check in Sofa.Simulation.SceneCheckMainRegistry.getRegisteredSceneChecks():
+        print(f"{scene_check.getName()}: {scene_check.getDesc()}")
+
+    # Call the above function to create the scene graph
+    root = Sofa.Core.Node("root")
+    createScene(root)
+
+    # Once defined, initialization of the scene graph
+    Sofa.Simulation.initRoot(root)
+
+# Function called when the scene graph is being created
+def createScene(root):
+
+    root.addObject('RequiredPlugin', name='Sofa.Component.StateContainer')
+
+    # Scene must now include a AnimationLoop
+    root.addObject('DefaultAnimationLoop')
+
+    # Add new nodes and objects in the scene
+    node1 = root.addChild("Node1")
+    node2 = root.addChild("Node2")
+
+    node1.addObject("MechanicalObject", template="Rigid3d", position="0 0 0   0 0 0 1", showObject="1")
+
+    node2.addObject("MechanicalObject", template="Rigid3d", position="1 1 1   0 0 0 1", showObject="1")
+
+    return root
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It allows:

```python
SofaRuntime.importPlugin("SceneChecking")

for scene_check in Sofa.Simulation.SceneCheckMainRegistry.getRegisteredSceneChecks():
    print(f"{scene_check.getName()}: {scene_check.getDesc()}")
```

Result:

```
SceneCheckCollisionResponse: Check that the appropriate components are in the scene to compute the desired collision response
SceneCheckDeprecatedComponents: Check there is not deprecated components in the scenegraph
SceneCheckDuplicatedName: Check there is not duplicated name in the scenegraph
SceneCheckEmptyNodeName: Check if a Node has an empty name.
SceneCheckMissingRequiredPlugin: Check for each component provided by a plugin that the corresponding <RequiredPlugin> directive is present in the scene
SceneCheckUsingAlias: Check if a Component has been created using an Alias.
```

It's not yet possible to call the validation due to limitations in SOFA.