### PR TITLE
Use built in method numpy.set_printoptions in addObject/addChild methods to enable numpy 2 

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -274,7 +274,7 @@ private:
 py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs& kwargs)
 {
     //Instantiating this object will make sure the numpy representation is fixed during the call of this function, and comes back to its previous state after
-    const NumpyReprFixerRAII numpyReprFixer;
+    [[maybe_unused]] const NumpyReprFixerRAII numpyReprFixer;
 
     std::string name {};
     if (kwargs.contains("name"))
@@ -402,7 +402,7 @@ py::object createObject(Node* self, const std::string& type, const py::kwargs& k
 py::object addChildKwargs(Node* self, const std::string& name, const py::kwargs& kwargs)
 {
     //Instantiating this object will make sure the numpy representation is fixed during the call of this function, and comes back to its previous state after
-    const NumpyReprFixerRAII numpyReprFixer;
+    [[maybe_unused]] const NumpyReprFixerRAII numpyReprFixer;
 
     if (sofapython3::isProtectedKeyword(name))
         throw py::value_error("addChild: Cannot call addChild with name " + name + ": Protected keyword");


### PR DESCRIPTION
Use set_printoptions(legacy=True) in node binding to force usage of legacy repr for numpy objects. This is compatible with numpy 1

This still uses string representation of all arguments when calling addObject or addChild, which reduces the possibles bugs. 