### PR TITLE
use the same name for SOFA_ROOT and script  to use runSofa

### DIFF
--- a/docs/sphinx/source/content/Installation.rst
+++ b/docs/sphinx/source/content/Installation.rst
@@ -85,12 +85,12 @@ Using SofaPython3 in runSofa requires loading the SofaPython3 plugin in your run
 		mv lib/plugin_list.conf.default lib/plugin_list.conf
 		{ echo "SofaPython3 NO_VERSION"; cat lib/plugin_list.conf; } > temp && mv temp lib/plugin_list.conf
 	..
-		
+
 Having the SofaPython3 plugin active will allow you to open scene files using the ".py, .py3, .pyscn, .pyscn3" file extension in runSofa, with the command :
 
 	.. code-block:: bash
 
-		<SOFA_build>/bin/runSofa <your_python_file>
+		<SOFA_ROOT>/build/v25.06/bin/runSofa <your_python_file>
 
 
 using python3

--- a/docs/sphinx/source/content/Installation.rst
+++ b/docs/sphinx/source/content/Installation.rst
@@ -75,15 +75,17 @@ Setup your environment
 using runSofa
 *************
 
-Using SofaPython3 in runSofa requires loading the SofaPython3 plugin in your runSofa environment. If you downloaded and installed SOFA from the SOFA website (as explained above, see :ref:`getsofapython3`), you can load the SofaPython3 plugin using the PluginManager (in the GUI) or by auto-loading the plugin in runSofa: simply copy the file **plugin_list.conf.default** in *<SOFA_build>/lib*, and rename it **plugin_list.conf**, then add the line:
+Using SofaPython3 in runSofa requires loading the SofaPython3 plugin in your runSofa environment. If you downloaded and installed SOFA from the SOFA website (as explained above, see :ref:`getsofapython3`), you can load the SofaPython3 plugin using the PluginManager (in the GUI) or by auto-loading the plugin in runSofa running the following script from the Sofa Root directory:
+
+ simply copy the file **plugin_list.conf.default** in *<SOFA_build>/lib*, and rename it **plugin_list.conf**, then add the line:
 
 	.. code-block:: text 
-
-		SofaPython3 NO_VERSION
-
+		cd <SOFA_ROOT>/build/v25.06/
+		cp lib/plugin_list.conf.default lib/plugin_list.conf.default.back
+		mv lib/plugin_list.conf.default lib/plugin_list.conf
+		{ echo "SofaPython3 NO_VERSION"; cat lib/plugin_list.conf; } > temp && mv temp lib/plugin_list.conf
 	..
-		Note that adding the line to the file **plugin_list.conf.default** in *<SOFA_build>/lib* would work, but you would need to add the line everytime you compile the code.
-
+		
 Having the SofaPython3 plugin active will allow you to open scene files using the ".py, .py3, .pyscn, .pyscn3" file extension in runSofa, with the command :
 
 	.. code-block:: bash


### PR DESCRIPTION
Instead of SOFA_build use <SOFA_ROOT>/build/v25.06/ to use the same naming everywhere in the documentation
