### PR TITLE
Add support for event pruning for the events overriden in python controllers

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -50,7 +50,7 @@ public:
     std::string getClassName() const override;
 
 private:
-    void callScriptMethod(const pybind11::object& self, sofa::core::objectmodel::Event* event,
+    bool callScriptMethod(const pybind11::object& self, sofa::core::objectmodel::Event* event,
         const std::string& methodName);
 };
 


### PR DESCRIPTION
Currently the controllers implemented in python cannot report the the event processing system in sofa that there is no need anymore to process the event.

The PR allows to do. Every onXXXXXX() that implement an event processor can no return a value. If it is None or False then processing of event use this to continue the propagation If it is True (aka: has been processed/no more further), then the SOFA system will not proposed to other component to process the same event

Connected with https://github.com/sofa-framework/sofa/pull/5749