### PR TITLE
Add Rigid3::Coord in the PythonFactory

### DIFF
--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -503,7 +503,12 @@ bool PythonFactory::registerDefaultTypes()
     PythonFactory::registerType<sofa::core::topology::Topology::Hexa>("Hexa");
     PythonFactory::registerType<sofa::core::topology::Topology::Penta>("Penta");
 
-    // State vectors
+    // Rigid
+    PythonFactory::registerType<sofa::defaulttype::Rigid3dTypes::Coord>("Rigid3d::Coord");
+    PythonFactory::registerType<sofa::defaulttype::Rigid3fTypes::Coord>("Rigid3f::Coord");
+    PythonFactory::registerType<sofa::defaulttype::Rigid3Types::Coord>("Rigid3::Coord");
+
+    // Rigid3 vectors
     PythonFactory::registerType<sofa::defaulttype::Rigid3dTypes::VecCoord>("Rigid3d::VecCoord");
     PythonFactory::registerType<sofa::defaulttype::Rigid3fTypes::VecCoord>("Rigid3f::VecCoord");
     PythonFactory::registerType<sofa::defaulttype::Rigid3Types::VecCoord>("Rigid3::VecCoord");


### PR DESCRIPTION
Because currently only Rigid3::VecCoord was supported.