### PR TITLE
Add context manager behavior to Node()

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -723,5 +723,18 @@ void moduleAddNode(py::module &m) {
     p.def("sendEvent", &sendEvent, sofapython3::doc::sofa::core::Node::sendEvent);
     p.def("computeEnergy", &computeEnergy, sofapython3::doc::sofa::core::Node::computeEnergy);
 
+    p.def("__enter__", [](py::object self)
+    {
+        if(pybind11::hasattr(self, "onCtxEnter"))
+            self.attr("onCtxEnter")(self);
+        return self;
+    });
+
+    p.def("__exit__",
+          [](py::object self, py::object type, py::object value, py::object traceback)
+    {
+        if(pybind11::hasattr(self, "onCtxExit"))
+            self.attr("onCtxExit")(self, type, value, traceback);
+    });
 }
 } /// namespace sofapython3


### PR DESCRIPTION
This allows to use with statement to have good looking indentation in sofa scene. eg:

```python
def createScene(root):
        with root.addChild("WW") as ww:
	       ww.addObject("YY")
```

It also allow to implement extra behavior in python as discussed in https://github.com/sofa-framework/sofa/discussions/5728

For example "creative use of the mechanism" allows to implement things like the following:  
```python

current_node = None
def setCurrentNode(node):
       global current_node
       current_node = node
def Node(name):
       global current_node
       self = current_node.addChild(name)
       
       def onCtxEnter(self):
             current_node = self
       
       def onCtxExit(self, type, value, excp):
             current_node = self.parents[0]
       current_node.onCtxEnter = onCtxEnter
       current_node.onCtxExit = onCtxExit
       return self
 
 def Object(type, **kwargs):
       global current_node 
       return current_node.addObject(type, **kwargs)
       
def createScene(root):
        setCurrentNode(root)
        with Node("WW")) as ww:
               with Node("II"):
                       Object("MechanicalObject", name="mo1", template="Vec3") 
  	       Object("MechanicalObject", name="mo2", template="Vec3")        
```
