### PR TITLE
Clean getRecords in Timer module

### DIFF
--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.cpp
@@ -33,7 +33,6 @@ namespace sofapython3
 {
 
 /**
-/**
  * @brief Converts AdvancedTimer records to a Python dictionary structure
  *
  * This function processes the timer records and builds a hierarchical Python dictionary


### PR DESCRIPTION
Main renaming, adding descriptive comments. Also factorized similar cases in the switch statement (RBEGIN and RSTEP_BEGIN are merged, REND and RSTEP_END are merged).