### PR TITLE
Follow lifecycle v26.06 deprecated header : task

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_TaskScheduler.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_TaskScheduler.cpp
@@ -19,8 +19,8 @@
 ******************************************************************************/
 
 #include <SofaPython3/Sofa/Core/Binding_TaskScheduler.h>
-#include <sofa/simulation/MainTaskSchedulerFactory.h>
-#include <sofa/simulation/TaskScheduler.h>
+#include <sofa/simulation/task/MainTaskSchedulerFactory.h>
+#include <sofa/simulation/task/TaskScheduler.h>
 #include <SofaPython3/Sofa/Core/Binding_TaskScheduler_doc.h>
 
 


### PR DESCRIPTION
Tasks are now sorted into a dedicated repository
Linked to https://github.com/sofa-framework/sofa/pull/5905 but can be merged as is!

[with-all-tests]