### PR TITLE
Add binding for `GetVersion` and associated unit tests

### DIFF
--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -195,6 +195,11 @@ def unloadModules():
     for name in toremove:
         del(sys.modules[name]) # unload it
 
+def GetVersion():
+    """Returns the version of SOFA as a string in the format 'vMM.mm', where MM is the major version and mm is the
+       minor version.
+    """
+    return Sofa.Helper.GetVersion()
 
 def formatStackForSofa(o):
     """ format the stack trace provided as a parameter into a string like that:

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.cpp
@@ -20,8 +20,11 @@
 
 #include <pybind11/pybind11.h>
 
-#include <SofaPython3/Sofa/Helper/Binding_Utils.h>
 #include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/Sofa/Helper/Binding_Utils.h>
+
+#include <iomanip>
+#include <sofa/version.h>
 
 #include <sofa/helper/Utils.h>
 
@@ -44,6 +47,20 @@ void moduleAddUtils(py::module &m) {
         Get the directory where is stored the sofa output data such as screenshots.
     )doc";
     utils.def_static("GetSofaDataDirectory", &sofa::helper::Utils::getSofaDataDirectory, GetSofaDataDirectoryDoc);
+
+    utils.def_static("GetVersion",
+        []()
+        {
+            std::stringstream version;
+            constexpr auto major = SOFA_VERSION / 10000;
+            constexpr auto minor = SOFA_VERSION / 100 % 100;
+            version << 'v'
+                << std::setfill('0') << std::setw(2) << major
+                << "."
+                << std::setfill('0') << std::setw(2) << minor;
+            return version.str();
+        },
+        "Returns the version of SOFA as a string in the format 'vMM.mm', where MM is the major version and mm is the minor version.");
 }
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Utils.cpp
@@ -51,14 +51,16 @@ void moduleAddUtils(py::module &m) {
     utils.def_static("GetVersion",
         []()
         {
-            std::stringstream version;
-            constexpr auto major = SOFA_VERSION / 10000;
-            constexpr auto minor = SOFA_VERSION / 100 % 100;
-            version << 'v'
-                << std::setfill('0') << std::setw(2) << major
-                << "."
-                << std::setfill('0') << std::setw(2) << minor;
-            return version.str();
+            static const std::string sofaVersion = []() {
+                std::stringstream version;
+                constexpr auto major = SOFA_VERSION / 10000;
+                constexpr auto minor = SOFA_VERSION / 100 % 100;
+                version << 'v'
+                    << std::setfill('0') << std::setw(2) << major
+                    << "."
+                    << std::setfill('0') << std::setw(2) << minor;
+                return version.str();
+            }();
         },
         "Returns the version of SOFA as a string in the format 'vMM.mm', where MM is the major version and mm is the minor version.");
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Version.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Version.cpp
@@ -20,30 +20,37 @@
 
 #include <pybind11/pybind11.h>
 
-#include <SofaPython3/Sofa/Helper/Binding_Utils.h>
 #include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/Sofa/Helper/Binding_Version.h>
 
-#include <sofa/helper/Utils.h>
+#include <iomanip>
+#include <sofa/version.h>
+
 
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
 
 namespace sofapython3
 {
-    
-void moduleAddUtils(py::module &m) {
-    py::class_<sofa::helper::Utils> utils(m, "Utils");
-    utils.doc() = "Utility class with convenient functions.";
 
-    const auto GetSofaUserLocalDirectoryDoc = R"doc(
-        Get the directory where is stored the sofa configuration.
-    )doc";
-    utils.def_static("GetSofaUserLocalDirectory", &sofa::helper::Utils::getSofaUserLocalDirectory, GetSofaUserLocalDirectoryDoc);
-    
-    const auto GetSofaDataDirectoryDoc = R"doc(
-        Get the directory where is stored the sofa output data such as screenshots.
-    )doc";
-    utils.def_static("GetSofaDataDirectory", &sofa::helper::Utils::getSofaDataDirectory, GetSofaDataDirectoryDoc);
+void moduleAddVersion(py::module &m)
+{
+    m.def("GetVersion",
+        []()
+        {
+            static const std::string sofaVersion = []() {
+                std::stringstream version;
+                constexpr auto major = SOFA_VERSION / 10000;
+                constexpr auto minor = SOFA_VERSION / 100 % 100;
+                version << 'v'
+                    << std::setfill('0') << std::setw(2) << major
+                    << "."
+                    << std::setfill('0') << std::setw(2) << minor;
+                return version.str();
+            }();
+            return sofaVersion;
+        },
+        "Returns the version of SOFA as a string in the format 'vMM.mm', where MM is the major version and mm is the minor version.");
 }
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Version.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Version.h
@@ -18,33 +18,13 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#pragma once
+
 #include <pybind11/pybind11.h>
-
-#include <SofaPython3/Sofa/Helper/Binding_Utils.h>
-#include <SofaPython3/PythonFactory.h>
-
-#include <sofa/helper/Utils.h>
-
-/// Makes an alias for the pybind11 namespace to increase readability.
-namespace py { using namespace pybind11; }
 
 namespace sofapython3
 {
-    
-void moduleAddUtils(py::module &m) {
-    py::class_<sofa::helper::Utils> utils(m, "Utils");
-    utils.doc() = "Utility class with convenient functions.";
 
-    const auto GetSofaUserLocalDirectoryDoc = R"doc(
-        Get the directory where is stored the sofa configuration.
-    )doc";
-    utils.def_static("GetSofaUserLocalDirectory", &sofa::helper::Utils::getSofaUserLocalDirectory, GetSofaUserLocalDirectoryDoc);
-    
-    const auto GetSofaDataDirectoryDoc = R"doc(
-        Get the directory where is stored the sofa output data such as screenshots.
-    )doc";
-    utils.def_static("GetSofaDataDirectory", &sofa::helper::Utils::getSofaDataDirectory, GetSofaDataDirectoryDoc);
-}
-
+void moduleAddVersion(pybind11::module &m);
 
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Bindings.Sofa.Helper)
 set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Utils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Vector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Version.h
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Submodule_System.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_MessageHandler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Binding_FileRepository.h
@@ -13,6 +14,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_MessageHandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Vector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Version.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Submodule_System.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/System/Binding_FileRepository.cpp
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -26,6 +26,7 @@
 #include <SofaPython3/Sofa/Helper/Binding_MessageHandler.h>
 #include <SofaPython3/Sofa/Helper/Binding_Vector.h>
 #include <SofaPython3/Sofa/Helper/Binding_Utils.h>
+#include <SofaPython3/Sofa/Helper/Binding_Version.h>
 
 /// Makes an alias for the pybind11 namespace to increase readability.
 namespace py { using namespace pybind11; }
@@ -153,6 +154,7 @@ PYBIND11_MODULE(Helper, helper)
     moduleAddVector(helper);
     moduleAddSystem(helper);
     moduleAddUtils(helper);
+    moduleAddVersion(helper);
 
     auto atexit = py::module_::import("atexit");
     atexit.attr("register")(py::cpp_function([]() {

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PYTHON_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Mass.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/MyRestShapeForceField.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Helper/Message.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/Helper/Version.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Simulation/Node.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Simulation/Simulation.py
     ${CMAKE_CURRENT_SOURCE_DIR}/Types/BoundingBox.py

--- a/bindings/Sofa/tests/Helper/Version.py
+++ b/bindings/Sofa/tests/Helper/Version.py
@@ -11,10 +11,10 @@ class GetVersionTest(unittest.TestCase):
     structure.
     """
     def test_exist(self):
-        self.assertTrue(hasattr(Sofa.Helper.Utils, "GetVersion"))
+        self.assertTrue(hasattr(Sofa.Helper, "GetVersion"))
 
     def test_version_format(self):
-        version = Sofa.Helper.Utils.GetVersion()
+        version = Sofa.Helper.GetVersion()
         print(f"SOFA Version: {version}")
         self.assertTrue(version.startswith('v'))
         version = version.replace('v', '')

--- a/bindings/Sofa/tests/Helper/Version.py
+++ b/bindings/Sofa/tests/Helper/Version.py
@@ -1,0 +1,26 @@
+import Sofa
+import Sofa.Helper
+import unittest
+
+class GetVersionTest(unittest.TestCase):
+    """
+    Contains unit tests for verifying the existence and format of the `GetVersion` method
+    in the `Sofa.Helper.Utils` module.
+
+    Includes tests to assert that the version is correctly formatted and meets the expected
+    structure.
+    """
+    def test_exist(self):
+        self.assertTrue(hasattr(Sofa.Helper.Utils, "GetVersion"))
+
+    def test_version_format(self):
+        version = Sofa.Helper.Utils.GetVersion()
+        print(f"SOFA Version: {version}")
+        self.assertTrue(version.startswith('v'))
+        version = version.replace('v', '')
+        self.assertTrue(version.count('.') == 1)
+        major, minor = version.split('.')
+        self.assertTrue(major.isdigit())
+        self.assertTrue(minor.isdigit())
+        self.assertEqual(len(major), 2)
+        self.assertEqual(len(minor), 2)


### PR DESCRIPTION
Introduce a static method `GetVersion` in `Sofa.Helper` to retrieve the SOFA version in `vMM.mm` format. Added unit tests in `Helper/Version.py` to verify existence and format adherence. Updated CMakeLists accordingly.