### PR TITLE
Add `getName` method to MessageHandler classes and bindings

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.cpp
@@ -83,6 +83,11 @@ namespace sofapython3
         }
     }
 
+    std::string MessageHandler_Trampoline::getName() const
+    {
+        PythonEnvironment::gil acquire {"MessageHandler::getName"};
+        return py::str(py::cast(this).get_type().attr("__name__"));
+    }
 
     void moduleAddMessageHandler(py::module &m) {
         py::class_<PyMessageHandler, MessageHandler_Trampoline> f(m, "MessageHandler", py::dynamic_attr(), "Manages and processes messages");

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_MessageHandler.h
@@ -33,12 +33,14 @@ namespace sofapython3 {
 class PyMessageHandler: public sofa::helper::logging::MessageHandler {
 public:
     void process(sofa::helper::logging::Message& m) override {SOFA_UNUSED(m);}
+    std::string getName() const override {return "PyMessageHandler";}
 };
 
 class MessageHandler_Trampoline : public PyMessageHandler
 {
 public:
     void process(sofa::helper::logging::Message& m) override ;
+    std::string getName() const override;
 };
 
 void moduleAddMessageHandler(pybind11::module &m);

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/PythonMessageHandler.h
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/PythonMessageHandler.h
@@ -31,6 +31,7 @@ class PythonMessageHandler : public sofa::helper::logging::MessageHandler
 public:
     PythonMessageHandler() = default;
     void process(sofa::helper::logging::Message& m) override ;
+    std::string getName() const override { return "PythonMessageHandler"; }
 };
 
 class MainPythonMessageHandler


### PR DESCRIPTION
Based on https://github.com/sofa-framework/sofa/pull/5979