### PR TITLE
Add binding for modifying and adding entries to sparse matrices

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_CompressedRowSparseMatrix.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_CompressedRowSparseMatrix.cpp
@@ -53,8 +53,16 @@ void bindCompressedRowSparseMatrixConstraint(pybind11::module& m)
 
     crsmc.def_property_readonly("value", [](sofa::Data<MatrixDeriv>& self)
     {
-        sofa::helper::ReadAccessor accessor(self);
+        sofa::helper::WriteAccessor accessor(self);
+        accessor.wref().compress();
         return toEigen(accessor.ref());
+    });
+
+    crsmc.def("add", [](sofa::Data<MatrixDeriv>& self, sofa::Index row, sofa::Index col, const MatrixDeriv::Block value)
+    {
+        sofa::helper::WriteAccessor accessor(self);
+        auto line = accessor->writeLine(row);
+        line.addCol(col, value);
     });
 
     PythonFactory::registerType(MatrixDeriv::Name(), [](sofa::core::BaseData* data) -> py::object {


### PR DESCRIPTION
Aiming at doing a Mapping written in Python (apply, applyJ, applyJT). The issue is that applyJT works with matrices and the binding does not allow for this