### PR TITLE
Component is the new controller

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseComponent.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseComponent.cpp
@@ -21,7 +21,6 @@
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseComponent.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseComponent_doc.h>
-#include <SofaPython3/Sofa/Core/Binding_Controller.h>
 #include <SofaPython3/PythonFactory.h>
 
 #include <sofa/core/ObjectFactory.h>

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
@@ -35,7 +35,7 @@ using sofa::core::objectmodel::BaseComponent;
 // ---------------------------------------------------------------------------
 
 Component_Trampoline::Component_Trampoline()
-    : TrampolineBase(this)   // pass this as BaseComponent* — no CRTP needed
+    : BasetTrampoline(this)   // pass this as BaseComponent* — no CRTP needed
 {
 }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
@@ -22,8 +22,8 @@
 #include <pybind11/cast.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
-#include <SofaPython3/Sofa/Core/Binding_Controller.h>
-#include <SofaPython3/Sofa/Core/Binding_Controller_doc.h>
+#include <SofaPython3/Sofa/Core/Binding_Component.h>
+#include <SofaPython3/Sofa/Core/Binding_Component_doc.h>
 
 #include <SofaPython3/PythonFactory.h>
 #include <SofaPython3/PythonEnvironment.h>
@@ -38,20 +38,20 @@ namespace sofapython3
 using sofa::core::objectmodel::Event;
 using sofa::core::objectmodel::BaseComponent;
 
-Controller_Trampoline::Controller_Trampoline() = default;
+Component_Trampoline::Component_Trampoline() = default;
 
-Controller_Trampoline::~Controller_Trampoline()
+Component_Trampoline::~Component_Trampoline()
 {
     // Clean up Python objects while holding the GIL
     if (m_cacheInitialized)
     {
-        PythonEnvironment::gil acquire {"~Controller_Trampoline"};
+        PythonEnvironment::gil acquire {"~Component_Trampoline"};
         m_methodCache.clear();
         m_pySelf = py::object();
     }
 }
 
-void Controller_Trampoline::initializePythonCache()
+void Component_Trampoline::initializePythonCache()
 {
     if (m_cacheInitialized)
         return;
@@ -65,7 +65,7 @@ void Controller_Trampoline::initializePythonCache()
     m_cacheInitialized = true;
 }
 
-py::object Controller_Trampoline::getCachedMethod(const std::string& methodName)
+py::object Component_Trampoline::getCachedMethod(const std::string& methodName)
 {
     // Must be called with GIL held and cache initialized
 
@@ -92,7 +92,7 @@ py::object Controller_Trampoline::getCachedMethod(const std::string& methodName)
     return method;
 }
 
-bool Controller_Trampoline::callCachedMethod(const py::object& method, Event* event)
+bool Component_Trampoline::callCachedMethod(const py::object& method, Event* event)
 {
     // Must be called with GIL held
     if (f_printLog.getValue())
@@ -108,7 +108,7 @@ bool Controller_Trampoline::callCachedMethod(const py::object& method, Event* ev
     return py::cast<bool>(result);
 }
 
-void Controller_Trampoline::invalidateMethodCache(const std::string& methodName)
+void Component_Trampoline::invalidateMethodCache(const std::string& methodName)
 {
     if (!m_cacheInitialized)
         return;
@@ -117,7 +117,7 @@ void Controller_Trampoline::invalidateMethodCache(const std::string& methodName)
     m_methodCache.erase(methodName);
 }
 
-std::string Controller_Trampoline::getClassName() const
+std::string Component_Trampoline::getClassName() const
 {
     PythonEnvironment::gil acquire {"getClassName"};
 
@@ -130,32 +130,32 @@ std::string Controller_Trampoline::getClassName() const
     return py::str(py::type::of(py::cast(this)).attr("__name__"));
 }
 
-void Controller_Trampoline::draw(const sofa::core::visual::VisualParams* params)
+void Component_Trampoline::draw(const sofa::core::visual::VisualParams* params)
 {
     PythonEnvironment::executePython(this, [this, params](){
-        PYBIND11_OVERLOAD(void, Controller, draw, params);
+        PYBIND11_OVERLOAD(void, Component, draw, params);
     });
 }
 
-void Controller_Trampoline::init()
+void Component_Trampoline::init()
 {
     PythonEnvironment::executePython(this, [this](){
         // Initialize the Python object cache on first init
         initializePythonCache();
-        PYBIND11_OVERLOAD(void, Controller, init, );
+        PYBIND11_OVERLOAD(void, Component, init, );
     });
 }
 
-void Controller_Trampoline::reinit()
+void Component_Trampoline::reinit()
 {
     PythonEnvironment::executePython(this, [this](){
-        PYBIND11_OVERLOAD(void, Controller, reinit, );
+        PYBIND11_OVERLOAD(void, Component, reinit, );
     });
 }
 
 /// If a method named "methodName" exists in the python controller,
 /// methodName is called, with the Event's dict as argument
-bool Controller_Trampoline::callScriptMethod(
+bool Component_Trampoline::callScriptMethod(
         const py::object& self, Event* event, const std::string & methodName)
 {
     if(f_printLog.getValue())
@@ -177,7 +177,7 @@ bool Controller_Trampoline::callScriptMethod(
     return false;
 }
 
-void Controller_Trampoline::handleEvent(Event* event)
+void Component_Trampoline::handleEvent(Event* event)
 {
     PythonEnvironment::executePython(this, [this, event](){
         // Ensure cache is initialized (in case init() wasn't called or
@@ -204,59 +204,87 @@ void Controller_Trampoline::handleEvent(Event* event)
     });
 }
 
-void moduleAddController(py::module &m) {
-    py::class_<Controller,
-            Controller_Trampoline,
+
+
+sofa::core::sptr<Component_Trampoline> Component_Trampoline::_init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs)
+{
+    auto c = sofa::core::sptr<Component_Trampoline> (new Component_Trampoline());
+    c->f_listening.setValue(true);
+
+    for(auto kv : kwargs)
+    {
+        std::string key = py::cast<std::string>(kv.first);
+        py::object value = py::reinterpret_borrow<py::object>(kv.second);
+
+        if( key == "name")
+            c->setName(py::cast<std::string>(kv.second));
+        try {
+            BindingBase::SetAttr(*c, key, value);
+        } catch (py::attribute_error& /*e*/) {
+            /// kwargs are used to set datafields to their initial values,
+            /// but they can also be used as simple python attributes, unrelated to SOFA.
+            /// thus we catch & ignore the py::attribute_error thrown by SetAttr
+        }
+    }
+    return c;
+}
+
+void Component_Trampoline::_setattr_(pybind11::object self, const std::string& s, pybind11::object value)
+{
+    // If the attribute starts with "on" and the new value is callable, invalidate the cached method
+    if (s.rfind("on", 0) == 0 && PyCallable_Check(value.ptr()))
+    {
+        auto* trampoline = dynamic_cast<Component_Trampoline*>(py::cast<Component*>(self));
+        if (trampoline)
+        {
+            trampoline->invalidateMethodCache(s);
+        }
+    }
+
+    // Delegate to the base class __setattr__
+    BindingBase::__setattr__(self, s, value);
+}
+
+
+
+void moduleAddComponent(py::module &m) {
+    py::class_<Component,
+            Component_Trampoline,
             BaseComponent,
-            py_shared_ptr<Controller>> f(m, "Controller",
+            py_shared_ptr<Component>> f(m, "Component",
                                          py::dynamic_attr(),
                                          sofapython3::doc::controller::controllerClass);
 
-    f.def(py::init([](py::args& /*args*/, py::kwargs& kwargs)
-          {
-              auto c = sofa::core::sptr<Controller_Trampoline> (new Controller_Trampoline());
-              c->f_listening.setValue(true);
+    f.def(py::init(&Component_Trampoline::_init_));
+    f.def("__setattr__",&Component_Trampoline::_setattr_);
 
-              for(auto kv : kwargs)
-              {
-                  std::string key = py::cast<std::string>(kv.first);
-                  py::object value = py::reinterpret_borrow<py::object>(kv.second);
-
-                  if( key == "name")
-                  c->setName(py::cast<std::string>(kv.second));
-                  try {
-                      BindingBase::SetAttr(*c, key, value);
-                  } catch (py::attribute_error& /*e*/) {
-                      /// kwargs are used to set datafields to their initial values,
-                      /// but they can also be used as simple python attributes, unrelated to SOFA.
-                      /// thus we catch & ignore the py::attribute_error thrown by SetAttr
-                  }
-              }
-              return c;
-          }));
-
-    f.def("init", &Controller::init);
-    f.def("reinit", &Controller::reinit);
-    f.def("draw", [](Controller& self, sofa::core::visual::VisualParams* params){
+    f.def("init", &Component::init);
+    f.def("reinit", &Component::reinit);
+    f.def("draw", [](Component& self, sofa::core::visual::VisualParams* params){
         self.draw(params);
     }, pybind11::return_value_policy::reference);
 
-    // Override __setattr__ to invalidate the method cache when an "on*" attribute is reassigned
-    f.def("__setattr__", [](py::object self, const std::string& s, py::object value) {
-        // If the attribute starts with "on" and the new value is callable, invalidate the cached method
-        if (s.rfind("on", 0) == 0 && PyCallable_Check(value.ptr()))
-        {
-            auto* trampoline = dynamic_cast<Controller_Trampoline*>(py::cast<Controller*>(self));
-            if (trampoline)
-            {
-                trampoline->invalidateMethodCache(s);
-            }
-        }
-
-        // Delegate to the base class __setattr__
-        BindingBase::__setattr__(self, s, value);
-    });
 }
+
+void moduleAddController(py::module &m) {
+    py::class_<Component,
+            Component_Trampoline,
+            BaseComponent,
+            py_shared_ptr<Component>> f(m, "Controller",
+                                         py::dynamic_attr(),
+                                         sofapython3::doc::controller::controllerClass);
+
+    f.def(py::init(&Component_Trampoline::_init_));
+    f.def("__setattr__",&Component_Trampoline::_setattr_);
+
+    f.def("init", &Component::init);
+    f.def("reinit", &Component::reinit);
+    f.def("draw", [](Component& self, sofa::core::visual::VisualParams* params){
+        self.draw(params);
+    }, pybind11::return_value_policy::reference);
+
+}
+
 
 
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
@@ -247,11 +247,11 @@ void Component_Trampoline::_setattr_(pybind11::object self, const std::string& s
 
 
 
-void moduleAddComponent(py::module &m) {
+void moduleAddBase(py::module &m, const std::string & name) {
     py::class_<Component,
             Component_Trampoline,
             BaseComponent,
-            py_shared_ptr<Component>> f(m, "Component",
+            py_shared_ptr<Component>> f(m, name.c_str(),
                                          py::dynamic_attr(),
                                          sofapython3::doc::controller::controllerClass);
 
@@ -267,22 +267,10 @@ void moduleAddComponent(py::module &m) {
 }
 
 void moduleAddController(py::module &m) {
-    py::class_<Component,
-            Component_Trampoline,
-            BaseComponent,
-            py_shared_ptr<Component>> f(m, "Controller",
-                                         py::dynamic_attr(),
-                                         sofapython3::doc::controller::controllerClass);
-
-    f.def(py::init(&Component_Trampoline::_init_));
-    f.def("__setattr__",&Component_Trampoline::_setattr_);
-
-    f.def("init", &Component::init);
-    f.def("reinit", &Component::reinit);
-    f.def("draw", [](Component& self, sofa::core::visual::VisualParams* params){
-        self.draw(params);
-    }, pybind11::return_value_policy::reference);
-
+    moduleAddBase(m, "Controller");
+}
+void moduleAddComponent(py::module &m) {
+    moduleAddBase(m, "Component");
 }
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.cpp
@@ -30,6 +30,14 @@ namespace sofapython3
 using sofa::core::objectmodel::Event;
 using sofa::core::objectmodel::BaseComponent;
 
+// ---------------------------------------------------------------------------
+// Component_Trampoline
+// ---------------------------------------------------------------------------
+
+Component_Trampoline::Component_Trampoline()
+    : TrampolineBase(this)   // pass this as BaseComponent* — no CRTP needed
+{
+}
 
 void Component_Trampoline::draw(const sofa::core::visual::VisualParams* params)
 {
@@ -41,7 +49,6 @@ void Component_Trampoline::draw(const sofa::core::visual::VisualParams* params)
 void Component_Trampoline::init()
 {
     PythonEnvironment::executePython(this, [this](){
-        // Initialize the Python object cache on first init
         initializePythonCache();
         PYBIND11_OVERLOAD(void, Component, init, );
     });
@@ -54,7 +61,6 @@ void Component_Trampoline::reinit()
     });
 }
 
-
 void Component_Trampoline::handleEvent(sofa::core::objectmodel::Event* event)
 {
     trampoline_handleEvent(event);
@@ -65,6 +71,10 @@ std::string Component_Trampoline::getClassName() const
     return trampoline_getClassName();
 }
 
+// ---------------------------------------------------------------------------
+// Module registration
+// ---------------------------------------------------------------------------
+
 void moduleAddComponent(py::module &m) {
     py::class_<Component,
         Component_Trampoline,
@@ -73,8 +83,8 @@ void moduleAddComponent(py::module &m) {
                                      py::dynamic_attr(),
                                      sofapython3::doc::component::componentClass);
 
-    f.def(py::init(&Trampoline_T<Component_Trampoline>::_init_));
-    f.def("__setattr__",&Trampoline_T<Component_Trampoline>::_setattr_);
+    f.def(py::init(&trampoline_init<Component_Trampoline>));
+    f.def("__setattr__", &trampoline_setattr<Component_Trampoline>);
 
     f.def("init", &Component::init);
     f.def("reinit", &Component::reinit);
@@ -83,6 +93,4 @@ void moduleAddComponent(py::module &m) {
     }, pybind11::return_value_policy::reference);
 }
 
-
-
-}
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
@@ -27,40 +27,27 @@
 
 namespace sofapython3 {
 
-/**
- * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseComponent doesn't have
- * them)
- */
-class Component : public sofa::core::objectmodel::BaseComponent {
-public:
-    SOFA_CLASS(Component, sofa::core::objectmodel::BaseComponent);
-    void init() override {};
-    void reinit() override {};
-};
 
-class Component_Trampoline : public Component
+template<class T>
+class Trampoline_T
 {
 public:
-    SOFA_CLASS(Component_Trampoline, Component);
 
-    Component_Trampoline();
-    ~Component_Trampoline() override;
+    virtual ~Trampoline_T();
 
-    void init() override;
-    void reinit() override;
-    void draw(const sofa::core::visual::VisualParams* params) override;
 
-    void handleEvent(sofa::core::objectmodel::Event* event) override;
+    void trampoline_handleEvent(sofa::core::objectmodel::Event* event);
 
-    std::string getClassName() const override;
+    std::string trampoline_getClassName() const;
 
     /// Invalidates a specific entry in the method cache (called when a user reassigns an on* attribute)
     void invalidateMethodCache(const std::string& methodName);
 
-    static sofa::core::sptr<Component_Trampoline> _init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs);
+    static sofa::core::sptr<T> _init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs);
+
     static void _setattr_(pybind11::object self, const std::string& s, pybind11::object value);
 
-private:
+protected:
     /// Initializes the Python object cache (m_pySelf and method cache)
     void initializePythonCache();
 
@@ -85,9 +72,37 @@ private:
     bool m_cacheInitialized = false;
 };
 
-void moduleAddBase(pybind11::module &m, const std::string & name);
+
+/**
+ * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseComponent doesn't have
+ * them)
+ */
+class Component : public sofa::core::objectmodel::BaseComponent {
+public:
+    SOFA_CLASS(Component, sofa::core::objectmodel::BaseComponent);
+    void init() override {};
+    void reinit() override {};
+};
+
+class Component_Trampoline : public Component, public Trampoline_T<Component_Trampoline>
+{
+public:
+    SOFA_CLASS(Component_Trampoline, Component);
+
+    Component_Trampoline() = default;
+    virtual ~Component_Trampoline() = default;
+
+    void init() override;
+    void reinit() override;
+    void draw(const sofa::core::visual::VisualParams* params) override;
+
+    void handleEvent(sofa::core::objectmodel::Event* event) override;
+
+    std::string getClassName() const override;
+
+};
+
 void moduleAddComponent(pybind11::module &m);
-void moduleAddController(pybind11::module &m);
 
 } /// namespace sofapython3
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
@@ -85,6 +85,7 @@ private:
     bool m_cacheInitialized = false;
 };
 
+void moduleAddBase(pybind11::module &m, const std::string & name);
 void moduleAddComponent(pybind11::module &m);
 void moduleAddController(pybind11::module &m);
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
@@ -28,81 +28,63 @@
 namespace sofapython3 {
 
 
-template<class T>
-class Trampoline_T
+class TrampolineBase
 {
 public:
-
-    virtual ~Trampoline_T();
-
+    explicit TrampolineBase(sofa::core::objectmodel::BaseComponent* self);
+    virtual ~TrampolineBase();
 
     void trampoline_handleEvent(sofa::core::objectmodel::Event* event);
-
     std::string trampoline_getClassName() const;
-
-    /// Invalidates a specific entry in the method cache (called when a user reassigns an on* attribute)
     void invalidateMethodCache(const std::string& methodName);
 
-    static sofa::core::sptr<T> _init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs);
-
-    static void _setattr_(pybind11::object self, const std::string& s, pybind11::object value);
-
 protected:
-    /// Initializes the Python object cache (m_pySelf and method cache)
     void initializePythonCache();
-
-    /// Returns a cached method if it exists, or an empty object if not
     pybind11::object getCachedMethod(const std::string& methodName);
-
-    /// Calls a cached Python method with the given event
     bool callCachedMethod(const pybind11::object& method, sofa::core::objectmodel::Event* event);
-
-    /// Legacy method for uncached calls (fallback)
     bool callScriptMethod(const pybind11::object& self, sofa::core::objectmodel::Event* event,
-        const std::string& methodName);
+                          const std::string& methodName);
 
-    /// Cached Python self reference (avoids repeated py::cast(this))
+    /// Raw non-owning pointer to the concrete trampoline as BaseComponent.
+    /// Safe because TrampolineBase is always embedded in the same object.
+    sofa::core::objectmodel::BaseComponent* m_componentSelf { nullptr };
+
     pybind11::object m_pySelf;
-
-    /// Cache of Python method objects, keyed by method name (including "onEvent" fallback)
-    /// Stores the method object if it exists, or an empty object if checked and not found
     std::unordered_map<std::string, pybind11::object> m_methodCache;
-
-    /// Flag indicating whether the cache has been initialized
     bool m_cacheInitialized = false;
 };
 
 
-/**
- * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseComponent doesn't have
- * them)
- */
+template<class T>
+sofa::core::sptr<T> trampoline_init(pybind11::args& /*args*/, pybind11::kwargs& kwargs);
+
+template<class T>
+void trampoline_setattr(pybind11::object self, const std::string& s, pybind11::object value);
+
+
+
 class Component : public sofa::core::objectmodel::BaseComponent {
 public:
     SOFA_CLASS(Component, sofa::core::objectmodel::BaseComponent);
-    void init() override {};
-    void reinit() override {};
+    void init() override {}
+    void reinit() override {}
 };
 
-class Component_Trampoline : public Component, public Trampoline_T<Component_Trampoline>
+class Component_Trampoline : public Component, public TrampolineBase
 {
 public:
     SOFA_CLASS(Component_Trampoline, Component);
 
-    Component_Trampoline() = default;
-    virtual ~Component_Trampoline() = default;
+    Component_Trampoline();
+    ~Component_Trampoline() override = default;
 
     void init() override;
     void reinit() override;
     void draw(const sofa::core::visual::VisualParams* params) override;
-
     void handleEvent(sofa::core::objectmodel::Event* event) override;
-
     std::string getClassName() const override;
-
 };
 
 void moduleAddComponent(pybind11::module &m);
 
 } /// namespace sofapython3
-

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
@@ -21,30 +21,30 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-#include <sofa/core/behavior/BaseController.h>
-#include <unordered_map>
+#include <sofa/core/objectmodel/BaseComponent.h>
 #include <string>
+#include <unordered_map>
 
 namespace sofapython3 {
 
 /**
- * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseController doesn't have
+ * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseComponent doesn't have
  * them)
  */
-class Controller : public sofa::core::behavior::BaseController {
+class Component : public sofa::core::objectmodel::BaseComponent {
 public:
-    SOFA_CLASS(Controller, sofa::core::behavior::BaseController);
+    SOFA_CLASS(Component, sofa::core::objectmodel::BaseComponent);
     void init() override {};
     void reinit() override {};
 };
 
-class Controller_Trampoline : public Controller
+class Component_Trampoline : public Component
 {
 public:
-    SOFA_CLASS(Controller_Trampoline, Controller);
+    SOFA_CLASS(Component_Trampoline, Component);
 
-    Controller_Trampoline();
-    ~Controller_Trampoline() override;
+    Component_Trampoline();
+    ~Component_Trampoline() override;
 
     void init() override;
     void reinit() override;
@@ -56,6 +56,9 @@ public:
 
     /// Invalidates a specific entry in the method cache (called when a user reassigns an on* attribute)
     void invalidateMethodCache(const std::string& methodName);
+
+    static sofa::core::sptr<Component_Trampoline> _init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs);
+    static void _setattr_(pybind11::object self, const std::string& s, pybind11::object value);
 
 private:
     /// Initializes the Python object cache (m_pySelf and method cache)
@@ -82,6 +85,7 @@ private:
     bool m_cacheInitialized = false;
 };
 
+void moduleAddComponent(pybind11::module &m);
 void moduleAddController(pybind11::module &m);
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
@@ -28,11 +28,11 @@
 namespace sofapython3 {
 
 
-class TrampolineBase
+class BasetTrampoline
 {
 public:
-    explicit TrampolineBase(sofa::core::objectmodel::BaseComponent* self);
-    ~TrampolineBase();
+    explicit BasetTrampoline(sofa::core::objectmodel::BaseComponent* self);
+    ~BasetTrampoline();
 
     void trampoline_handleEvent(sofa::core::objectmodel::Event* event);
     std::string trampoline_getClassName() const;
@@ -46,7 +46,7 @@ protected:
                           const std::string& methodName);
 
     /// Raw non-owning pointer to the concrete trampoline as BaseComponent.
-    /// Safe because TrampolineBase is always embedded in the same object.
+    /// Safe because BasetTrampoline is always embedded in the same object.
     sofa::core::objectmodel::BaseComponent* m_componentSelf { nullptr };
 
     pybind11::object m_pySelf;
@@ -70,7 +70,7 @@ public:
     void reinit() override {}
 };
 
-class Component_Trampoline : public Component, public TrampolineBase
+class Component_Trampoline : public Component, public BasetTrampoline
 {
 public:
     SOFA_CLASS(Component_Trampoline, Component);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.h
@@ -32,7 +32,7 @@ class TrampolineBase
 {
 public:
     explicit TrampolineBase(sofa::core::objectmodel::BaseComponent* self);
-    virtual ~TrampolineBase();
+    ~TrampolineBase();
 
     void trampoline_handleEvent(sofa::core::objectmodel::Event* event);
     std::string trampoline_getClassName() const;
@@ -76,7 +76,6 @@ public:
     SOFA_CLASS(Component_Trampoline, Component);
 
     Component_Trampoline();
-    ~Component_Trampoline() override = default;
 
     void init() override;
     void reinit() override;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
@@ -57,7 +57,7 @@ void Trampoline_T<T>::initializePythonCache()
         return;
 
     // Must be called with GIL held
-    m_pySelf = py::cast(this);
+    m_pySelf = py::cast(dynamic_cast<T*>(this));
 
     // Pre-cache the fallback "onEvent" method via the standard cache path
     getCachedMethod("onEvent");
@@ -96,12 +96,14 @@ py::object Trampoline_T<T>::getCachedMethod(const std::string& methodName)
 template<class T>
 bool Trampoline_T<T>::callCachedMethod(const py::object& method, Event* event)
 {
+    auto thisT = dynamic_cast<T*>(this);
+
     // Must be called with GIL held
-    // if (f_printLog.getValue())
-    // {
-    //     std::string eventStr = py::str(PythonFactory::toPython(event));
-    //     msg_info() << "on" << event->getClassName() << " " << eventStr;
-    // }
+    if (thisT->f_printLog.getValue())
+    {
+        std::string eventStr = py::str(PythonFactory::toPython(event));
+        msg_info(thisT) << "on" << event->getClassName() << " " << eventStr;
+    }
 
     py::object result = method(PythonFactory::toPython(event));
     if (result.is_none())
@@ -140,12 +142,14 @@ template<class T>
 bool Trampoline_T<T>::callScriptMethod(
         const py::object& self, Event* event, const std::string & methodName)
 {
-    // if(f_printLog.getValue())
-    // {
-    //     std::string name = std::string("on")+event->getClassName();
-    //     std::string eventStr = py::str(PythonFactory::toPython(event));
-    //     msg_info() << name << " " << eventStr;
-    // }
+    auto thisT = dynamic_cast<T*>(this);
+
+    if(thisT->f_printLog.getValue())
+    {
+        std::string name = std::string("on")+event->getClassName();
+        std::string eventStr = py::str(PythonFactory::toPython(event));
+        msg_info(thisT) << name << " " << eventStr;
+    }
 
     if( py::hasattr(self, methodName.c_str()) )
     {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
@@ -19,14 +19,12 @@
 ******************************************************************************/
 #pragma once
 
-
 #include <pybind11/pybind11.h>
 #include <pybind11/cast.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_Component.h>
 #include <SofaPython3/Sofa/Core/Binding_Component_doc.h>
-
 #include <SofaPython3/PythonFactory.h>
 #include <SofaPython3/PythonEnvironment.h>
 
@@ -38,71 +36,60 @@ namespace sofapython3
 using sofa::core::objectmodel::Event;
 using sofa::core::objectmodel::BaseComponent;
 
-template<class T>
-Trampoline_T<T>::~Trampoline_T()
+
+inline TrampolineBase::TrampolineBase(BaseComponent* self)
+    : m_componentSelf(self)
 {
-    // Clean up Python objects while holding the GIL
+}
+
+inline TrampolineBase::~TrampolineBase()
+{
     if (m_cacheInitialized)
     {
-        PythonEnvironment::gil acquire {"~Component_Trampoline"};
+        PythonEnvironment::gil acquire {"~TrampolineBase"};
         m_methodCache.clear();
         m_pySelf = py::object();
     }
 }
 
-template<class T>
-void Trampoline_T<T>::initializePythonCache()
+inline void TrampolineBase::initializePythonCache()
 {
     if (m_cacheInitialized)
         return;
 
-    // Must be called with GIL held
-    m_pySelf = py::cast(static_cast<T*>(this));
+    // py::cast on the BaseComponent* will find the most-derived registered
+    // pybind11 type (e.g. the user's Python subclass), which is exactly what
+    // we want — no need for static_cast<T*>(this) anymore.
+    m_pySelf = py::cast(m_componentSelf);
 
-    // Pre-cache the fallback "onEvent" method via the standard cache path
     getCachedMethod("onEvent");
-
     m_cacheInitialized = true;
 }
 
-template<class T>
-py::object Trampoline_T<T>::getCachedMethod(const std::string& methodName)
+inline py::object TrampolineBase::getCachedMethod(const std::string& methodName)
 {
-    // Must be called with GIL held and cache initialized
-
-    // Check if we've already looked up this method
     auto it = m_methodCache.find(methodName);
     if (it != m_methodCache.end())
-    {
         return it->second;
-    }
 
-    // First time looking up this method - check if it exists
     py::object method;
     if (py::hasattr(m_pySelf, methodName.c_str()))
     {
         py::object fct = m_pySelf.attr(methodName.c_str());
         if (PyCallable_Check(fct.ptr()))
-        {
             method = fct;
-        }
     }
 
-    // Cache the result (even if empty, to avoid repeated hasattr checks)
     m_methodCache[methodName] = method;
     return method;
 }
 
-template<class T>
-bool Trampoline_T<T>::callCachedMethod(const py::object& method, Event* event)
+inline bool TrampolineBase::callCachedMethod(const py::object& method, Event* event)
 {
-    auto thisT = static_cast<T*>(this);
-
-    // Must be called with GIL held
-    if (thisT->f_printLog.getValue())
+    if (m_componentSelf->f_printLog.getValue())
     {
         std::string eventStr = py::str(PythonFactory::toPython(event));
-        msg_info(thisT) << "on" << event->getClassName() << " " << eventStr;
+        msg_info(m_componentSelf) << "on" << event->getClassName() << " " << eventStr;
     }
 
     py::object result = method(PythonFactory::toPython(event));
@@ -112,72 +99,53 @@ bool Trampoline_T<T>::callCachedMethod(const py::object& method, Event* event)
     return py::cast<bool>(result);
 }
 
-template<class T>
-void Trampoline_T<T>::invalidateMethodCache(const std::string& methodName)
+inline void TrampolineBase::invalidateMethodCache(const std::string& methodName)
 {
     if (!m_cacheInitialized)
         return;
-
-    // Remove the entry so getCachedMethod will re-resolve it on next call
     m_methodCache.erase(methodName);
 }
 
-template<class T>
-std::string Trampoline_T<T>::trampoline_getClassName() const
+inline std::string TrampolineBase::trampoline_getClassName() const
 {
     PythonEnvironment::gil acquire {"getClassName"};
 
     if (m_pySelf)
-    {
         return py::str(py::type::of(m_pySelf).attr("__name__"));
-    }
 
-    // Fallback for when cache isn't initialized yet
-    return py::str(py::type::of(py::cast(this)).attr("__name__"));
+    // Fallback before cache is initialized: cast via BaseComponent*
+    return py::str(py::type::of(py::cast(m_componentSelf)).attr("__name__"));
 }
 
-/// If a method named "methodName" exists in the python controller,
-/// methodName is called, with the Event's dict as argument
-template<class T>
-bool Trampoline_T<T>::callScriptMethod(
-        const py::object& self, Event* event, const std::string & methodName)
+inline bool TrampolineBase::callScriptMethod(
+    const py::object& self, Event* event, const std::string& methodName)
 {
-    auto thisT = static_cast<T*>(this);
-
-    if(thisT->f_printLog.getValue())
+    if (m_componentSelf->f_printLog.getValue())
     {
-        std::string name = std::string("on")+event->getClassName();
+        std::string name = std::string("on") + event->getClassName();
         std::string eventStr = py::str(PythonFactory::toPython(event));
-        msg_info(thisT) << name << " " << eventStr;
+        msg_info(m_componentSelf) << name << " " << eventStr;
     }
 
-    if( py::hasattr(self, methodName.c_str()) )
+    if (py::hasattr(self, methodName.c_str()))
     {
         py::object fct = self.attr(methodName.c_str());
         py::object result = fct(PythonFactory::toPython(event));
-        if(result.is_none())
+        if (result.is_none())
             return false;
-
         return py::cast<bool>(result);
     }
     return false;
 }
 
-template<class T>
-void Trampoline_T<T>::trampoline_handleEvent(Event* event)
+inline void TrampolineBase::trampoline_handleEvent(Event* event)
 {
-    PythonEnvironment::executePython(static_cast<T*>(this), [this, event](){
-        // Ensure cache is initialized (in case init() wasn't called or
-        // handleEvent is called before init)
+    PythonEnvironment::executePython(m_componentSelf, [this, event](){
         if (!m_cacheInitialized)
-        {
             initializePythonCache();
-        }
 
-        // Build the event-specific method name (e.g., "onAnimateBeginEvent")
         std::string methodName = std::string("on") + event->getClassName();
 
-        // Try the event-specific method first, then fall back to generic "onEvent"
         py::object method = getCachedMethod(methodName);
         if (!method)
             method = getCachedMethod("onEvent");
@@ -192,46 +160,38 @@ void Trampoline_T<T>::trampoline_handleEvent(Event* event)
 }
 
 
-
 template<class T>
-sofa::core::sptr<T>  Trampoline_T<T>::_init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs)
+sofa::core::sptr<T> trampoline_init(py::args& /*args*/, py::kwargs& kwargs)
 {
-    auto c = sofa::core::sptr<T> (new T());
+    auto c = sofa::core::sptr<T>(new T());
     c->f_listening.setValue(true);
 
-    for(auto kv : kwargs)
+    for (auto kv : kwargs)
     {
         std::string key = py::cast<std::string>(kv.first);
         py::object value = py::reinterpret_borrow<py::object>(kv.second);
 
-        if( key == "name")
+        if (key == "name")
             c->setName(py::cast<std::string>(kv.second));
         try {
             BindingBase::SetAttr(*c, key, value);
         } catch (py::attribute_error& /*e*/) {
-            /// kwargs are used to set datafields to their initial values,
-            /// but they can also be used as simple python attributes, unrelated to SOFA.
-            /// thus we catch & ignore the py::attribute_error thrown by SetAttr
+            // kwargs may be plain Python attributes unrelated to SOFA — ignore
         }
     }
     return c;
 }
 
 template<class T>
-void Trampoline_T<T>::_setattr_(pybind11::object self, const std::string& s, pybind11::object value)
+void trampoline_setattr(py::object self, const std::string& s, py::object value)
 {
-    // If the attribute starts with "on" and the new value is callable, invalidate the cached method
     if (s.rfind("on", 0) == 0 && PyCallable_Check(value.ptr()))
     {
         auto* trampoline = dynamic_cast<T*>(py::cast<BaseComponent*>(self));
         if (trampoline)
-        {
             trampoline->invalidateMethodCache(s);
-        }
     }
-
-    // Delegate to the base class __setattr__
     BindingBase::__setattr__(self, s, value);
 }
 
-}
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
@@ -57,7 +57,7 @@ void Trampoline_T<T>::initializePythonCache()
         return;
 
     // Must be called with GIL held
-    m_pySelf = py::cast(dynamic_cast<T*>(this));
+    m_pySelf = py::cast(static_cast<T*>(this));
 
     // Pre-cache the fallback "onEvent" method via the standard cache path
     getCachedMethod("onEvent");
@@ -96,7 +96,7 @@ py::object Trampoline_T<T>::getCachedMethod(const std::string& methodName)
 template<class T>
 bool Trampoline_T<T>::callCachedMethod(const py::object& method, Event* event)
 {
-    auto thisT = dynamic_cast<T*>(this);
+    auto thisT = static_cast<T*>(this);
 
     // Must be called with GIL held
     if (thisT->f_printLog.getValue())
@@ -142,7 +142,7 @@ template<class T>
 bool Trampoline_T<T>::callScriptMethod(
         const py::object& self, Event* event, const std::string & methodName)
 {
-    auto thisT = dynamic_cast<T*>(this);
+    auto thisT = static_cast<T*>(this);
 
     if(thisT->f_printLog.getValue())
     {
@@ -166,7 +166,7 @@ bool Trampoline_T<T>::callScriptMethod(
 template<class T>
 void Trampoline_T<T>::trampoline_handleEvent(Event* event)
 {
-    PythonEnvironment::executePython(dynamic_cast<T*>(this), [this, event](){
+    PythonEnvironment::executePython(static_cast<T*>(this), [this, event](){
         // Ensure cache is initialized (in case init() wasn't called or
         // handleEvent is called before init)
         if (!m_cacheInitialized)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
@@ -1,0 +1,233 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+
+
+#include <pybind11/pybind11.h>
+#include <pybind11/cast.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_Component.h>
+#include <SofaPython3/Sofa/Core/Binding_Component_doc.h>
+
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/PythonEnvironment.h>
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+namespace sofapython3
+{
+using sofa::core::objectmodel::Event;
+using sofa::core::objectmodel::BaseComponent;
+
+template<class T>
+Trampoline_T<T>::~Trampoline_T()
+{
+    // Clean up Python objects while holding the GIL
+    if (m_cacheInitialized)
+    {
+        PythonEnvironment::gil acquire {"~Component_Trampoline"};
+        m_methodCache.clear();
+        m_pySelf = py::object();
+    }
+}
+
+template<class T>
+void Trampoline_T<T>::initializePythonCache()
+{
+    if (m_cacheInitialized)
+        return;
+
+    // Must be called with GIL held
+    m_pySelf = py::cast(this);
+
+    // Pre-cache the fallback "onEvent" method via the standard cache path
+    getCachedMethod("onEvent");
+
+    m_cacheInitialized = true;
+}
+
+template<class T>
+py::object Trampoline_T<T>::getCachedMethod(const std::string& methodName)
+{
+    // Must be called with GIL held and cache initialized
+
+    // Check if we've already looked up this method
+    auto it = m_methodCache.find(methodName);
+    if (it != m_methodCache.end())
+    {
+        return it->second;
+    }
+
+    // First time looking up this method - check if it exists
+    py::object method;
+    if (py::hasattr(m_pySelf, methodName.c_str()))
+    {
+        py::object fct = m_pySelf.attr(methodName.c_str());
+        if (PyCallable_Check(fct.ptr()))
+        {
+            method = fct;
+        }
+    }
+
+    // Cache the result (even if empty, to avoid repeated hasattr checks)
+    m_methodCache[methodName] = method;
+    return method;
+}
+
+template<class T>
+bool Trampoline_T<T>::callCachedMethod(const py::object& method, Event* event)
+{
+    // Must be called with GIL held
+    // if (f_printLog.getValue())
+    // {
+    //     std::string eventStr = py::str(PythonFactory::toPython(event));
+    //     msg_info() << "on" << event->getClassName() << " " << eventStr;
+    // }
+
+    py::object result = method(PythonFactory::toPython(event));
+    if (result.is_none())
+        return false;
+
+    return py::cast<bool>(result);
+}
+
+template<class T>
+void Trampoline_T<T>::invalidateMethodCache(const std::string& methodName)
+{
+    if (!m_cacheInitialized)
+        return;
+
+    // Remove the entry so getCachedMethod will re-resolve it on next call
+    m_methodCache.erase(methodName);
+}
+
+template<class T>
+std::string Trampoline_T<T>::trampoline_getClassName() const
+{
+    PythonEnvironment::gil acquire {"getClassName"};
+
+    if (m_pySelf)
+    {
+        return py::str(py::type::of(m_pySelf).attr("__name__"));
+    }
+
+    // Fallback for when cache isn't initialized yet
+    return py::str(py::type::of(py::cast(this)).attr("__name__"));
+}
+
+/// If a method named "methodName" exists in the python controller,
+/// methodName is called, with the Event's dict as argument
+template<class T>
+bool Trampoline_T<T>::callScriptMethod(
+        const py::object& self, Event* event, const std::string & methodName)
+{
+    // if(f_printLog.getValue())
+    // {
+    //     std::string name = std::string("on")+event->getClassName();
+    //     std::string eventStr = py::str(PythonFactory::toPython(event));
+    //     msg_info() << name << " " << eventStr;
+    // }
+
+    if( py::hasattr(self, methodName.c_str()) )
+    {
+        py::object fct = self.attr(methodName.c_str());
+        py::object result = fct(PythonFactory::toPython(event));
+        if(result.is_none())
+            return false;
+
+        return py::cast<bool>(result);
+    }
+    return false;
+}
+
+template<class T>
+void Trampoline_T<T>::trampoline_handleEvent(Event* event)
+{
+    PythonEnvironment::executePython(dynamic_cast<T*>(this), [this, event](){
+        // Ensure cache is initialized (in case init() wasn't called or
+        // handleEvent is called before init)
+        if (!m_cacheInitialized)
+        {
+            initializePythonCache();
+        }
+
+        // Build the event-specific method name (e.g., "onAnimateBeginEvent")
+        std::string methodName = std::string("on") + event->getClassName();
+
+        // Try the event-specific method first, then fall back to generic "onEvent"
+        py::object method = getCachedMethod(methodName);
+        if (!method)
+            method = getCachedMethod("onEvent");
+
+        if (method)
+        {
+            bool isHandled = callCachedMethod(method, event);
+            if (isHandled)
+                event->setHandled();
+        }
+    });
+}
+
+
+
+template<class T>
+sofa::core::sptr<T>  Trampoline_T<T>::_init_(pybind11::args& /*args*/, pybind11::kwargs& kwargs)
+{
+    auto c = sofa::core::sptr<T> (new T());
+    c->f_listening.setValue(true);
+
+    for(auto kv : kwargs)
+    {
+        std::string key = py::cast<std::string>(kv.first);
+        py::object value = py::reinterpret_borrow<py::object>(kv.second);
+
+        if( key == "name")
+            c->setName(py::cast<std::string>(kv.second));
+        try {
+            BindingBase::SetAttr(*c, key, value);
+        } catch (py::attribute_error& /*e*/) {
+            /// kwargs are used to set datafields to their initial values,
+            /// but they can also be used as simple python attributes, unrelated to SOFA.
+            /// thus we catch & ignore the py::attribute_error thrown by SetAttr
+        }
+    }
+    return c;
+}
+
+template<class T>
+void Trampoline_T<T>::_setattr_(pybind11::object self, const std::string& s, pybind11::object value)
+{
+    // If the attribute starts with "on" and the new value is callable, invalidate the cached method
+    if (s.rfind("on", 0) == 0 && PyCallable_Check(value.ptr()))
+    {
+        auto* trampoline = dynamic_cast<T*>(py::cast<BaseComponent*>(self));
+        if (trampoline)
+        {
+            trampoline->invalidateMethodCache(s);
+        }
+    }
+
+    // Delegate to the base class __setattr__
+    BindingBase::__setattr__(self, s, value);
+}
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component.inl
@@ -37,22 +37,22 @@ using sofa::core::objectmodel::Event;
 using sofa::core::objectmodel::BaseComponent;
 
 
-inline TrampolineBase::TrampolineBase(BaseComponent* self)
+inline BasetTrampoline::BasetTrampoline(BaseComponent* self)
     : m_componentSelf(self)
 {
 }
 
-inline TrampolineBase::~TrampolineBase()
+inline BasetTrampoline::~BasetTrampoline()
 {
     if (m_cacheInitialized)
     {
-        PythonEnvironment::gil acquire {"~TrampolineBase"};
+        PythonEnvironment::gil acquire {"~BasetTrampoline"};
         m_methodCache.clear();
         m_pySelf = py::object();
     }
 }
 
-inline void TrampolineBase::initializePythonCache()
+inline void BasetTrampoline::initializePythonCache()
 {
     if (m_cacheInitialized)
         return;
@@ -66,7 +66,7 @@ inline void TrampolineBase::initializePythonCache()
     m_cacheInitialized = true;
 }
 
-inline py::object TrampolineBase::getCachedMethod(const std::string& methodName)
+inline py::object BasetTrampoline::getCachedMethod(const std::string& methodName)
 {
     auto it = m_methodCache.find(methodName);
     if (it != m_methodCache.end())
@@ -84,7 +84,7 @@ inline py::object TrampolineBase::getCachedMethod(const std::string& methodName)
     return method;
 }
 
-inline bool TrampolineBase::callCachedMethod(const py::object& method, Event* event)
+inline bool BasetTrampoline::callCachedMethod(const py::object& method, Event* event)
 {
     if (m_componentSelf->f_printLog.getValue())
     {
@@ -99,14 +99,14 @@ inline bool TrampolineBase::callCachedMethod(const py::object& method, Event* ev
     return py::cast<bool>(result);
 }
 
-inline void TrampolineBase::invalidateMethodCache(const std::string& methodName)
+inline void BasetTrampoline::invalidateMethodCache(const std::string& methodName)
 {
     if (!m_cacheInitialized)
         return;
     m_methodCache.erase(methodName);
 }
 
-inline std::string TrampolineBase::trampoline_getClassName() const
+inline std::string BasetTrampoline::trampoline_getClassName() const
 {
     PythonEnvironment::gil acquire {"getClassName"};
 
@@ -117,7 +117,7 @@ inline std::string TrampolineBase::trampoline_getClassName() const
     return py::str(py::type::of(py::cast(m_componentSelf)).attr("__name__"));
 }
 
-inline bool TrampolineBase::callScriptMethod(
+inline bool BasetTrampoline::callScriptMethod(
     const py::object& self, Event* event, const std::string& methodName)
 {
     if (m_componentSelf->f_printLog.getValue())
@@ -138,7 +138,7 @@ inline bool TrampolineBase::callScriptMethod(
     return false;
 }
 
-inline void TrampolineBase::trampoline_handleEvent(Event* event)
+inline void BasetTrampoline::trampoline_handleEvent(Event* event)
 {
     PythonEnvironment::executePython(m_componentSelf, [this, event](){
         if (!m_cacheInitialized)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component_doc.h
@@ -43,10 +43,10 @@ static auto controllerClass =
 
                 import Sofa.Core
 
-                class MyController(Sofa.Core.Controller):
+                class MyComponent(Sofa.Core.Component):
                     def __init__(self, *args, **kwargs):
                          ## These are needed (and the normal way to override from a python class)
-                         Sofa.Core.Controller.__init__(self, *args, **kwargs)
+                         Sofa.Core.Component.__init__(self, *args, **kwargs)
                          print(" Python::__init__::"+str(self.name))
 
                     def onEvent(self, event):
@@ -59,7 +59,7 @@ static auto controllerClass =
                          print("onAnimateBeginEvent")
 
                 def createScene(rootNode):
-                    controller = MyController(name="MyC")
+                    controller = MyComponent(name="MyC")
                     rootNode.addObject(controller)
                     return rootNode
          )";

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Component_doc.h
@@ -24,19 +24,21 @@ namespace sofapython3::doc::component
 {
 static auto componentClass =
         R"(
-        Overridable class for user interaction on SOFA Components
+        Overridable class for SOFA Components
 
         It can catch events to trigger actions, such as onAnimateBeginEvent, onAnimateEndEvent or onPythonScriptEvent.
-        A new custom controller class needs to be defined to use a controller in a script,
+        A new custom Components class needs to be defined to use a Components in a script,
         and that class needs to reimplement the __init__ method.
 
         :example of use:
 
-        In the following example, we redefine the controller class, and reimplement the __init__ method.
-        We also implement the onAnimateBeginEvent, that will be activted everytime an animation step ends
+        In the following example, we redefine the Components class, and reimplement the __init__ method.
+        We also implement the init and onAnimateBeginEvent methods, the last one will be activted everytime an animation step ends
         and that will simply print a message in the command line. In the createScene function, we initialize
-        the controller and add it to the rootNode.
-        If you run this with runSofa, it will simply endlessly print `onAnimateBeginEvent`
+        the Components and add it to the rootNode.
+        If you run this with runSofa, it will first print "Init component" before you start the simulation, then
+        it will simply endlessly print `onAnimateBeginEvent`
+
         when you click the Animate button.
 
             .. code-block:: python
@@ -45,18 +47,24 @@ static auto componentClass =
 
                 class MyComponent(Sofa.Core.Component):
                     def __init__(self, *args, **kwargs):
-                         ## These are needed (and the normal way to override from a python class)
-                         Sofa.Core.Component.__init__(self, *args, **kwargs)
-                         print(" Python::__init__::"+str(self.name))
+                        ## These are needed (and the normal way to override from a python class)
+                        Sofa.Core.Component.__init__(self, *args, **kwargs)
+                        print(" Python::__init__::"+str(self.name))
+
+                    def init():
+                        """This function is called at the initialization stage of the component.
+                           Right after the call to 'createScene' when the root node is initialized.
+                        """
+                        print("Init component")
 
                     def onEvent(self, event):
-                         """This function is the fallback one that is called if the XXXX event is
-                            received but there is not overriden onXXXX() method.
-                         """
-                         print("generic event handler catched ", event)
+                        """This function is the fallback one that is called if the XXXX event is
+                           received but there is not overriden onXXXX() method.
+                        """
+                        print("generic event handler catched ", event)
 
                     def onAnimateBeginEvent(self, event):
-                         print("onAnimateBeginEvent")
+                        print("onAnimateBeginEvent")
 
                 def createScene(rootNode):
                     controller = MyComponent(name="MyC")

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -18,7 +18,16 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <pybind11/pybind11.h>
+#include <pybind11/cast.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_Controller.h>
 #include <SofaPython3/Sofa/Core/Binding_Component.inl>
+#include <SofaPython3/Sofa/Core/Binding_Controller_doc.h>
+
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/PythonEnvironment.h>
 
 SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
 
@@ -28,60 +37,59 @@ namespace py { using namespace pybind11; }
 namespace sofapython3
 {
 using sofa::core::objectmodel::Event;
-using sofa::core::objectmodel::BaseComponent;
+using sofa::core::behavior::BaseController;
 
-
-void Component_Trampoline::draw(const sofa::core::visual::VisualParams* params)
+void Controller_Trampoline::draw(const sofa::core::visual::VisualParams* params)
 {
     PythonEnvironment::executePython(this, [this, params](){
-        PYBIND11_OVERLOAD(void, Component, draw, params);
+        PYBIND11_OVERLOAD(void, Controller, draw, params);
     });
 }
 
-void Component_Trampoline::init()
+void Controller_Trampoline::init()
 {
     PythonEnvironment::executePython(this, [this](){
         // Initialize the Python object cache on first init
         initializePythonCache();
-        PYBIND11_OVERLOAD(void, Component, init, );
+        PYBIND11_OVERLOAD(void, Controller, init, );
     });
 }
 
-void Component_Trampoline::reinit()
+void Controller_Trampoline::reinit()
 {
     PythonEnvironment::executePython(this, [this](){
-        PYBIND11_OVERLOAD(void, Component, reinit, );
+        PYBIND11_OVERLOAD(void, Controller, reinit, );
     });
 }
 
 
-void Component_Trampoline::handleEvent(sofa::core::objectmodel::Event* event)
+void Controller_Trampoline::handleEvent(sofa::core::objectmodel::Event* event)
 {
     trampoline_handleEvent(event);
 }
 
-std::string Component_Trampoline::getClassName() const
+std::string Controller_Trampoline::getClassName() const
 {
     return trampoline_getClassName();
 }
 
-void moduleAddComponent(py::module &m) {
-    py::class_<Component,
-        Component_Trampoline,
-        BaseComponent,
-        py_shared_ptr<Component>> f(m, "Component",
-                                     py::dynamic_attr(),
-                                     sofapython3::doc::component::componentClass);
 
-    f.def(py::init(&Trampoline_T<Component_Trampoline>::_init_));
-    f.def("__setattr__",&Trampoline_T<Component_Trampoline>::_setattr_);
+void moduleAddController(py::module &m) {
+    py::class_<Controller,
+                Controller_Trampoline,
+                BaseComponent,
+                py_shared_ptr<Controller>> f(m, "Controller",
+                                             py::dynamic_attr(),
+                                             sofapython3::doc::controller::controllerClass);
 
-    f.def("init", &Component::init);
-    f.def("reinit", &Component::reinit);
-    f.def("draw", [](Component& self, sofa::core::visual::VisualParams* params){
+    f.def(py::init(&Trampoline_T<Controller_Trampoline>::_init_));
+    f.def("__setattr__",&Trampoline_T<Controller_Trampoline>::_setattr_);
+
+    f.def("init", &Controller::init);
+    f.def("reinit", &Controller::reinit);
+    f.def("draw", [](Controller& self, sofa::core::visual::VisualParams* params){
         self.draw(params);
-    }, pybind11::return_value_policy::reference);
-}
+    }, pybind11::return_value_policy::reference);}
 
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -43,7 +43,7 @@ using sofa::core::behavior::BaseController;
 // ---------------------------------------------------------------------------
 
 Controller_Trampoline::Controller_Trampoline()
-    : TrampolineBase(this)   // pass this as BaseComponent* — no CRTP needed
+    : BasetTrampoline(this)   // pass this as BaseComponent* — no CRTP needed
 {
 }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -25,7 +25,6 @@
 #include <SofaPython3/Sofa/Core/Binding_Controller.h>
 #include <SofaPython3/Sofa/Core/Binding_Component.inl>
 #include <SofaPython3/Sofa/Core/Binding_Controller_doc.h>
-
 #include <SofaPython3/PythonFactory.h>
 #include <SofaPython3/PythonEnvironment.h>
 
@@ -39,6 +38,15 @@ namespace sofapython3
 using sofa::core::objectmodel::Event;
 using sofa::core::behavior::BaseController;
 
+// ---------------------------------------------------------------------------
+// Controller_Trampoline
+// ---------------------------------------------------------------------------
+
+Controller_Trampoline::Controller_Trampoline()
+    : TrampolineBase(this)   // pass this as BaseComponent* — no CRTP needed
+{
+}
+
 void Controller_Trampoline::draw(const sofa::core::visual::VisualParams* params)
 {
     PythonEnvironment::executePython(this, [this, params](){
@@ -49,7 +57,6 @@ void Controller_Trampoline::draw(const sofa::core::visual::VisualParams* params)
 void Controller_Trampoline::init()
 {
     PythonEnvironment::executePython(this, [this](){
-        // Initialize the Python object cache on first init
         initializePythonCache();
         PYBIND11_OVERLOAD(void, Controller, init, );
     });
@@ -62,7 +69,6 @@ void Controller_Trampoline::reinit()
     });
 }
 
-
 void Controller_Trampoline::handleEvent(sofa::core::objectmodel::Event* event)
 {
     trampoline_handleEvent(event);
@@ -73,6 +79,9 @@ std::string Controller_Trampoline::getClassName() const
     return trampoline_getClassName();
 }
 
+// ---------------------------------------------------------------------------
+// Module registration
+// ---------------------------------------------------------------------------
 
 void moduleAddController(py::module &m) {
     py::class_<Controller,
@@ -82,15 +91,14 @@ void moduleAddController(py::module &m) {
                                              py::dynamic_attr(),
                                              sofapython3::doc::controller::controllerClass);
 
-    f.def(py::init(&Trampoline_T<Controller_Trampoline>::_init_));
-    f.def("__setattr__",&Trampoline_T<Controller_Trampoline>::_setattr_);
+    f.def(py::init(&trampoline_init<Controller_Trampoline>));
+    f.def("__setattr__", &trampoline_setattr<Controller_Trampoline>);
 
     f.def("init", &Controller::init);
     f.def("reinit", &Controller::reinit);
     f.def("draw", [](Controller& self, sofa::core::visual::VisualParams* params){
         self.draw(params);
-    }, pybind11::return_value_policy::reference);}
-
-
-
+    }, pybind11::return_value_policy::reference);
 }
+
+} // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <sofa/core/behavior/BaseController.h>
+#include <SofaPython3/Sofa/Core/Binding_Component.h>
+#include <string>
+#include <unordered_map>
+
+namespace sofapython3 {
+
+/**
+ * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseController doesn't have
+ * them)
+ */
+class Controller : public sofa::core::behavior::BaseController {
+public:
+    SOFA_CLASS(Controller, sofa::core::behavior::BaseController);
+    void init() override {};
+    void reinit() override {};
+};
+
+class Controller_Trampoline : public Controller, public Trampoline_T<Controller_Trampoline>
+{
+public:
+    SOFA_CLASS(Controller_Trampoline, Controller);
+
+    Controller_Trampoline() = default;
+
+    void init() override;
+    void reinit() override;
+    void draw(const sofa::core::visual::VisualParams* params) override;
+
+    void handleEvent(sofa::core::objectmodel::Event* event) override;
+
+    std::string getClassName() const override;
+
+};
+
+void moduleAddController(pybind11::module &m);
+
+} /// namespace sofapython3
+

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -38,7 +38,7 @@ public:
     void reinit() override {}
 };
 
-class Controller_Trampoline : public Controller, public TrampolineBase
+class Controller_Trampoline : public Controller, public BasetTrampoline
 {
 public:
     SOFA_CLASS(Controller_Trampoline, Controller);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -44,7 +44,6 @@ public:
     SOFA_CLASS(Controller_Trampoline, Controller);
 
     Controller_Trampoline();
-    ~Controller_Trampoline() override = default;
 
     void init() override;
     void reinit() override;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -24,40 +24,35 @@
 #include <sofa/core/behavior/BaseController.h>
 #include <SofaPython3/Sofa/Core/Binding_Component.h>
 #include <string>
-#include <unordered_map>
 
 namespace sofapython3 {
 
 /**
- * Empty controller shell that allows pybind11 to bind the init and reinit methods (since BaseController doesn't have
- * them)
+ * Empty controller shell that allows pybind11 to bind init and reinit
+ * (BaseController doesn't declare them as virtual).
  */
 class Controller : public sofa::core::behavior::BaseController {
 public:
     SOFA_CLASS(Controller, sofa::core::behavior::BaseController);
-    void init() override {};
-    void reinit() override {};
+    void init() override {}
+    void reinit() override {}
 };
 
-class Controller_Trampoline : public Controller, public Trampoline_T<Controller_Trampoline>
+class Controller_Trampoline : public Controller, public TrampolineBase
 {
 public:
     SOFA_CLASS(Controller_Trampoline, Controller);
 
-    Controller_Trampoline() = default;
-    virtual ~Controller_Trampoline() = default ;
+    Controller_Trampoline();
+    ~Controller_Trampoline() override = default;
 
     void init() override;
     void reinit() override;
     void draw(const sofa::core::visual::VisualParams* params) override;
-
     void handleEvent(sofa::core::objectmodel::Event* event) override;
-
     std::string getClassName() const override;
-
 };
 
 void moduleAddController(pybind11::module &m);
 
 } /// namespace sofapython3
-

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -45,6 +45,7 @@ public:
     SOFA_CLASS(Controller_Trampoline, Controller);
 
     Controller_Trampoline() = default;
+    virtual ~Controller_Trampoline() = default ;
 
     void init() override;
     void reinit() override;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller_doc.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
-namespace sofapython3::doc::component
+namespace sofapython3::doc::controller
 {
-static auto componentClass =
+static auto controllerClass =
         R"(
-        Overridable class for user interaction on SOFA Components
+        Overridable class for user interaction on SOFA Controllers
 
         It can catch events to trigger actions, such as onAnimateBeginEvent, onAnimateEndEvent or onPythonScriptEvent.
         A new custom controller class needs to be defined to use a controller in a script,
@@ -43,10 +43,10 @@ static auto componentClass =
 
                 import Sofa.Core
 
-                class MyComponent(Sofa.Core.Component):
+                class MyController(Sofa.Core.Controller):
                     def __init__(self, *args, **kwargs):
                          ## These are needed (and the normal way to override from a python class)
-                         Sofa.Core.Component.__init__(self, *args, **kwargs)
+                         Sofa.Core.Controller.__init__(self, *args, **kwargs)
                          print(" Python::__init__::"+str(self.name))
 
                     def onEvent(self, event):
@@ -59,7 +59,7 @@ static auto componentClass =
                          print("onAnimateBeginEvent")
 
                 def createScene(rootNode):
-                    controller = MyComponent(name="MyC")
+                    controller = MyController(name="MyC")
                     rootNode.addObject(controller)
                     return rootNode
          )";

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -15,8 +15,8 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ContactListener.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ContactListener_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Context.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Controller.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Controller_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DrawTool.h
@@ -68,7 +68,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_BaseContext.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ContactListener.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Context.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Controller.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataContainer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataString.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/CMakeLists.txt
@@ -16,7 +16,10 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ContactListener_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Context.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component.inl
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Controller.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Controller_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DrawTool.h
@@ -69,6 +72,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_ContactListener.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Component.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_Controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Binding_DataEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataContainer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Data/Binding_DataString.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -34,7 +34,7 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Binding_Mass.h>
 #include <SofaPython3/Sofa/Core/Binding_ContactListener.h>
 #include <SofaPython3/Sofa/Core/Binding_Context.h>
-#include <SofaPython3/Sofa/Core/Binding_Controller.h>
+#include <SofaPython3/Sofa/Core/Binding_Component.h>
 #include <SofaPython3/Sofa/Core/Binding_DataEngine.h>
 #include <SofaPython3/Sofa/Core/Binding_ObjectFactory.h>
 #include <SofaPython3/Sofa/Core/Binding_LinkPath.h>
@@ -142,6 +142,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddBaseCamera(core);
     moduleAddContactListener(core);
     moduleAddContext(core);
+    moduleAddComponent(core);
     moduleAddController(core);
     moduleAddDataEngine(core);
     moduleAddForceField(core);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -35,6 +35,7 @@ using sofa::helper::logging::Message;
 #include <SofaPython3/Sofa/Core/Binding_ContactListener.h>
 #include <SofaPython3/Sofa/Core/Binding_Context.h>
 #include <SofaPython3/Sofa/Core/Binding_Component.h>
+#include <SofaPython3/Sofa/Core/Binding_Controller.h>
 #include <SofaPython3/Sofa/Core/Binding_DataEngine.h>
 #include <SofaPython3/Sofa/Core/Binding_ObjectFactory.h>
 #include <SofaPython3/Sofa/Core/Binding_LinkPath.h>


### PR DESCRIPTION
While working on prefabs we have a new type of python object that is to be stored in the graph, so it needs to inherit from BaseComponent somehow. The dirty way to do this was to inherit from Controller which doesn't make sens as it is not meant to be actively doing something. 

At first I only wanted to make a python class named Component until I realized that it was meaningless without an ability to override handleEvent. Looking at that I realized that BaseContoller is nothing more than a BaseObject. So merging both makes sense.  

This PR keeps the old Controller implementation, just replaced the name to Component and added both to the python bindings. Therefore, such as in the actual core of SOFA, we have controllers and components which are basically the same but named differently 