### PR TITLE
Fix Clang compilation

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_CompressedRowSparseMatrix.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_CompressedRowSparseMatrix.cpp
@@ -58,7 +58,7 @@ void bindCompressedRowSparseMatrixConstraint(pybind11::module& m)
         return toEigen(accessor.ref());
     });
 
-    crsmc.def("add", [](sofa::Data<MatrixDeriv>& self, sofa::Index row, sofa::Index col, const MatrixDeriv::Block value)
+    crsmc.def("add", [](sofa::Data<MatrixDeriv>& self, sofa::Index row, sofa::Index col, const typename MatrixDeriv::Block value)
     {
         sofa::helper::WriteAccessor accessor(self);
         auto line = accessor->writeLine(row);


### PR DESCRIPTION
Since added bindings for CompresedRowSparseMatrix, the Clang compilaiton is broken on the main CI. This fixes it.  