### PR TITLE
Ensure stdout and stderr are not None before flushing

### DIFF
--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -161,7 +161,10 @@ if sofa_root and sys.platform == 'win32':
             os.environ['PATH'] = sofapython3_bin_path + os.pathsep + os.environ.get('PATH', '')
 
 print("---------------------------------------")
-sys.stdout.flush()
+if sys.stdout is not None:
+    sys.stdout.flush()
+if sys.stderr is not None:
+    sys.stderr.flush() 
 
 import Sofa.constants
 import Sofa.Helper


### PR DESCRIPTION
We have an error there while integrating SofaPython3 inside Unity application.