### PR TITLE
Enable scene checking when launching through python

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -71,7 +71,7 @@ PYBIND11_MODULE(Simulation, simulation)
     {
         auto& pluginManager = sofa::helper::system::PluginManager::getInstance();
         auto res = pluginManager.loadPlugin("SceneChecking");
-        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || res == sofa::helper::system::PluginLoadStatus::ALREADY_LOADED)
+        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || res == sofa::helper::system::PluginManager::PluginLoadStatus::ALREADY_LOADED)
         {
             sofa::simulation::SceneCheckerVisitor sceneCheckerVisitor;
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -71,7 +71,7 @@ PYBIND11_MODULE(Simulation, simulation)
     {
         auto& pluginManager = sofa::helper::system::PluginManager::getInstance();
         auto res = pluginManager.loadPlugin("SceneChecking");
-        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS)
+        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || res == PluginLoadStatus::ALREADY_LOADED)
         {
             sofa::simulation::SceneCheckerVisitor sceneCheckerVisitor;
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -71,7 +71,7 @@ PYBIND11_MODULE(Simulation, simulation)
     {
         auto& pluginManager = sofa::helper::system::PluginManager::getInstance();
         auto res = pluginManager.loadPlugin("SceneChecking");
-        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || res == PluginLoadStatus::ALREADY_LOADED)
+        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS || res == sofa::helper::system::PluginLoadStatus::ALREADY_LOADED)
         {
             sofa::simulation::SceneCheckerVisitor sceneCheckerVisitor;
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -43,6 +43,9 @@ using sofa::simulation::Simulation;
 #include <sofa/simulation/init.h>
 #include <sofa/simulation/common/init.h>
 #include <sofa/simulation/graph/init.h>
+#include <sofa/simulation/SceneCheckerVisitor.h>
+#include <sofa/simulation/SceneCheckMainRegistry.h>
+#include <sofa/helper/system/PluginManager.h>
 
 namespace py = pybind11;
 
@@ -64,7 +67,27 @@ PYBIND11_MODULE(Simulation, simulation)
     simulation.def("print", [](Node* n){ sofa::simulation::node::print(n); }, sofapython3::doc::simulation::print);
     simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::node::animate(n, dt); },sofapython3::doc::simulation::animate);
     simulation.def("init", [](Node* n){ sofa::simulation::node::init(n); }, sofapython3::doc::simulation::init);
-    simulation.def("initRoot", [](Node* n){ sofa::simulation::node::initRoot(n); }, sofapython3::doc::simulation::initRoot);
+    simulation.def("initRoot", [](Node* n)
+    {
+        auto& pluginManager = sofa::helper::system::PluginManager::getInstance();
+        auto res = pluginManager.loadPlugin("SceneChecking");
+        if(res == sofa::helper::system::PluginManager::PluginLoadStatus::SUCCESS)
+        {
+            sofa::simulation::SceneCheckerVisitor sceneCheckerVisitor;
+
+            for (const auto& sceneCheck : sofa::simulation::SceneCheckMainRegistry::getRegisteredSceneChecks())
+            {
+                sceneCheckerVisitor.addCheck(sceneCheck);
+            }
+
+            sceneCheckerVisitor.validate(n, nullptr);
+        }
+        else
+        {
+            msg_warning("Could not load SceneChecking, no scene check will be performed.");
+        }
+        sofa::simulation::node::initRoot(n);
+    }, sofapython3::doc::simulation::initRoot);
     simulation.def("initVisual", [](Node* n){ n->getVisualLoop()->initStep(sofa::core::visual::VisualParams::defaultInstance()); }, sofapython3::doc::simulation::initVisual);
     simulation.def("reset", [](Node* n){ sofa::simulation::node::reset(n); }, sofapython3::doc::simulation::reset);
   

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -52,22 +52,9 @@ namespace py = pybind11;
 namespace sofapython3
 {
 
-PYBIND11_MODULE(Simulation, simulation)
+void initRoot(Node* n, bool enableSceneChecking = true)
 {
-    // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
-    sofa::core::init();
-    sofa::simulation::core::init();
-    sofa::simulation::graph::init();
-
-    simulation.doc() =sofapython3::doc::simulation::Class;
-
-    moduleAddSceneCheck(simulation);
-    moduleAddSceneCheckMainRegistry(simulation);
-
-    simulation.def("print", [](Node* n){ sofa::simulation::node::print(n); }, sofapython3::doc::simulation::print);
-    simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::node::animate(n, dt); },sofapython3::doc::simulation::animate);
-    simulation.def("init", [](Node* n){ sofa::simulation::node::init(n); }, sofapython3::doc::simulation::init);
-    simulation.def("initRoot", [](Node* n)
+    if (enableSceneChecking)
     {
         auto& pluginManager = sofa::helper::system::PluginManager::getInstance();
         auto res = pluginManager.loadPlugin("SceneChecking");
@@ -86,8 +73,28 @@ PYBIND11_MODULE(Simulation, simulation)
         {
             msg_warning("Could not load SceneChecking, no scene check will be performed.");
         }
-        sofa::simulation::node::initRoot(n);
-    }, sofapython3::doc::simulation::initRoot);
+    }
+    sofa::simulation::node::initRoot(n);
+}
+
+PYBIND11_MODULE(Simulation, simulation)
+{
+    // These are needed to force the dynamic loading of module dependencies (found in CMakeLists.txt)
+    sofa::core::init();
+    sofa::simulation::core::init();
+    sofa::simulation::graph::init();
+
+    simulation.doc() =sofapython3::doc::simulation::Class;
+
+    moduleAddSceneCheck(simulation);
+    moduleAddSceneCheckMainRegistry(simulation);
+
+    simulation.def("print", [](Node* n){ sofa::simulation::node::print(n); }, sofapython3::doc::simulation::print);
+    simulation.def("animate", [](Node* n, SReal dt=0.0){ sofa::simulation::node::animate(n, dt); },sofapython3::doc::simulation::animate);
+    simulation.def("init", [](Node* n){ sofa::simulation::node::init(n); }, sofapython3::doc::simulation::init);
+    simulation.def("initRoot", [](Node* n) {initRoot( n, true );}, sofapython3::doc::simulation::initRoot);
+    simulation.def("initRoot", [](Node* n, bool enableSceneChecking) {initRoot( n, enableSceneChecking );}, sofapython3::doc::simulation::initRoot);
+
     simulation.def("initVisual", [](Node* n){ n->getVisualLoop()->initStep(sofa::core::visual::VisualParams::defaultInstance()); }, sofapython3::doc::simulation::initVisual);
     simulation.def("reset", [](Node* n){ sofa::simulation::node::reset(n); }, sofapython3::doc::simulation::reset);
   


### PR DESCRIPTION
:warning: Based on SOFA PR [#6150](https://github.com/sofa-framework/sofa/pull/6150), don't merge before :warning: 

Before, scenes launched using python where not checked with scene checking. 
Now it is launched during the initRoot call when the library is found. 

I am open to add a default parameter to initRoot `checks=True` so that it can be deactivated when we want to batch launch scenes. 

