### PR TITLE
[Python] Set the current cwd to the scene's path

### DIFF
--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -160,6 +160,25 @@ if sofa_root and sys.platform == 'win32':
         if sofapython3_file_test and sofapython3_bin_path:
             os.environ['PATH'] = sofapython3_bin_path + os.pathsep + os.environ.get('PATH', '')
 
+# Set the Current Working Directory of the process with the path of the scene file.
+# (to be consistent with the original runSofa)
+def get_entry_script():
+    # Try the main module's __file__ first (works for -m and normal scripts)
+    import __main__
+    if hasattr(__main__, '__file__'):
+        return os.path.abspath(__main__.__file__)
+
+    # Fallback to sys.argv[0] if available
+    if sys.argv[0]:
+        return os.path.abspath(sys.argv[0])
+
+    # Interactive shell or unknown context
+    return None
+
+entry_point = get_entry_script()
+if entry_point:
+    os.chdir(os.path.abspath(os.path.dirname(entry_point)))
+
 print("---------------------------------------")
 if sys.stdout is not None:
     sys.stdout.flush()


### PR DESCRIPTION
## Current Status
1️⃣ lots of calls to load resources (like MeshOBJLoader, image, etc) using FileRepository::findFiles() need the Current Working Directory (CWD) to be set to the scene's (see https://github.com/sofa-framework/sofa/pull/6135 )

2️⃣ with runSofa, this is set:
- in XML: through SceneLoaderXML : 
https://github.com/sofa-framework/sofa/blob/bc64d21b6961e2f80af0f0b43d8f46cd1249f618/Sofa/framework/Simulation/Common/src/sofa/simulation/common/SceneLoaderXML.cpp#L114

- in Python3: with SceneLoaderPY3: 
https://github.com/sofa-framework/SofaPython3/blob/e6fb484573778923e61220c8b5d73268d7c576a8/Plugin/src/SofaPython3/SceneLoaderPY3.cpp#L112

## Problem
When running directly with python (the process), the CWD is never changed and is set from where you launch it.
So it means that if you do, with a scene using relative paths:
- `cd ${HOME} ; python3 <dir_of_your_scene>/blabla.py` it wont work 
- `cd ${dir_of_your_scene} ; python3 blabla.py` it will work

which is... problematic in my opinion.

## Fix
So this PR sets the CWD from the directory of the script when doing `import Sofa`

---
NB1: I dont really like that things in the scene depends of the CWD anyway (but I wont obviously not change anything in the Sofa code base 🥴)
NB2: `SetDirectory` is such a bad name for the CWD changer in SOFA (plus it is doing other useful filesystem things and not really related to CWD)
