### PR TITLE
[SOFA.Units] Take input unit ratio into account when creating a scaled unit

### DIFF
--- a/bindings/Sofa/package/Units/Core.py
+++ b/bindings/Sofa/package/Units/Core.py
@@ -147,7 +147,10 @@ class ScaledUnit(Unit):
     def __init__(self, unit : Unit, ratio : float):
         self.numerator = unit.numerator.copy()
         self.denumerator = unit.denumerator.copy()
+
         self.ratio = ratio
+        if hasattr(unit, "ratio"):
+             self.ratio *= unit.ratio
 
 
 class DimensionnedValue():


### PR DESCRIPTION
The current implementation fo "ScaledUnits" expect only pure units as input (unit that are not scaled, meaning that they are the SI units). This PR take the current ratio of the input unit into account when creating a scaled unit from another one. 